### PR TITLE
TG-2704 | isActive parameter is unnecessary and being deprecated

### DIFF
--- a/twingate/client.go
+++ b/twingate/client.go
@@ -81,7 +81,7 @@ func NewAPIError(wrappedError error, operation string, resource string) *APIErro
 }
 
 func (e *APIError) Error() string {
-	var a = make([]interface{}, 0, 2) //nolint:mnd
+	var a = make([]interface{}, 0, 2) //nolint:gomnd
 	a = append(a, e.Operation, e.Resource)
 
 	var format = "failed to %s %s"

--- a/twingate/client.go
+++ b/twingate/client.go
@@ -81,7 +81,7 @@ func NewAPIError(wrappedError error, operation string, resource string) *APIErro
 }
 
 func (e *APIError) Error() string {
-	var a = make([]interface{}, 0, 2)
+	var a = make([]interface{}, 0, 2) //nolint:mnd
 	a = append(a, e.Operation, e.Resource)
 
 	var format = "failed to %s %s"

--- a/twingate/client_remote_network.go
+++ b/twingate/client_remote_network.go
@@ -15,7 +15,7 @@ func (client *Client) createRemoteNetwork(remoteNetworkName string) (*RemoteNetw
 	mutation := map[string]string{
 		"query": fmt.Sprintf(`
 			mutation{
-			  remoteNetworkCreate(name: "%s", isActive: true) {
+			  remoteNetworkCreate(name: "%s") {
 				ok
 				error
 				entity {

--- a/twingate/client_resource.go
+++ b/twingate/client_resource.go
@@ -66,7 +66,7 @@ type Resources struct {
 const resourceResourceName = "resource"
 
 func validatePort(port string) (int64, error) {
-	parsed, err := strconv.ParseInt(port, 10, 64)
+	parsed, err := strconv.ParseInt(port, 10, 64) //nolint:gomnd
 	if err != nil {
 		return 0, fmt.Errorf("port is not a valid integer: %w", err)
 	}
@@ -83,7 +83,7 @@ func convertPorts(ports []string) (string, error) {
 
 	for _, elem := range ports {
 		if strings.Contains(elem, "-") {
-			split := strings.SplitN(elem, "-", 2)
+			split := strings.SplitN(elem, "-", 2) //nolint:gomnd
 
 			start, err := validatePort(split[0])
 			if err != nil {


### PR DESCRIPTION
> JIRA Ticket URL: TG-2704 

## Changes
- When creating a remote network it is not necessary to send an `isActive` argument

