### PR TITLE
Updated graphql client in provider to expose string types instead of graphql

### DIFF
--- a/twingate/client_connector.go
+++ b/twingate/client_connector.go
@@ -34,13 +34,13 @@ type updateConnectorQuery struct {
 	} `graphql:"connectorUpdate(id: $connectorId, name: $connectorName )"`
 }
 
-func (client *Client) createConnector(ctx context.Context, remoteNetworkID graphql.ID) (*Connector, error) {
-	if remoteNetworkID.(string) == "" {
+func (client *Client) createConnector(ctx context.Context, remoteNetworkID string) (*Connector, error) {
+	if remoteNetworkID == "" {
 		return nil, NewAPIError(ErrGraphqlNetworkIDIsEmpty, "create", connectorResourceName)
 	}
 
 	variables := map[string]interface{}{
-		"remoteNetworkId": remoteNetworkID,
+		"remoteNetworkId": graphql.ID(remoteNetworkID),
 	}
 	response := createConnectorQuery{}
 
@@ -61,14 +61,14 @@ func (client *Client) createConnector(ctx context.Context, remoteNetworkID graph
 	return &connector, nil
 }
 
-func (client *Client) updateConnector(ctx context.Context, connectorID graphql.ID, connectorName graphql.String) error {
-	if connectorID.(string) == "" {
+func (client *Client) updateConnector(ctx context.Context, connectorID string, connectorName string) error {
+	if connectorID == "" {
 		return NewAPIError(ErrGraphqlConnectorIDIsEmpty, "update", connectorResourceName)
 	}
 
 	variables := map[string]interface{}{
-		"connectorId":   connectorID,
-		"connectorName": connectorName,
+		"connectorId":   graphql.ID(connectorID),
+		"connectorName": graphql.String(connectorName),
 	}
 	response := updateConnectorQuery{}
 
@@ -115,13 +115,13 @@ type readConnectorQuery struct {
 	} `graphql:"connector(id: $id)"`
 }
 
-func (client *Client) readConnector(ctx context.Context, connectorID graphql.ID) (*Connector, error) {
-	if connectorID.(string) == "" {
+func (client *Client) readConnector(ctx context.Context, connectorID string) (*Connector, error) {
+	if connectorID == "" {
 		return nil, NewAPIError(ErrGraphqlIDIsEmpty, "read", connectorResourceName)
 	}
 
 	variables := map[string]interface{}{
-		"id": connectorID,
+		"id": graphql.ID(connectorID),
 	}
 
 	response := readConnectorQuery{}
@@ -153,13 +153,13 @@ type deleteConnectorQuery struct {
 	ConnectorDelete *OkError `graphql:"connectorDelete(id: $id)" json:"connectorDelete"`
 }
 
-func (client *Client) deleteConnector(ctx context.Context, connectorID graphql.ID) error {
-	if connectorID.(string) == "" {
+func (client *Client) deleteConnector(ctx context.Context, connectorID string) error {
+	if connectorID == "" {
 		return NewAPIError(ErrGraphqlIDIsEmpty, "delete", connectorResourceName)
 	}
 
 	variables := map[string]interface{}{
-		"id": connectorID,
+		"id": graphql.ID(connectorID),
 	}
 
 	response := deleteConnectorQuery{}

--- a/twingate/client_connector_test.go
+++ b/twingate/client_connector_test.go
@@ -3,11 +3,11 @@ package twingate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"github.com/twingate/go-graphql-client"
 )
 
 func TestClientConnectorCreateOk(t *testing.T) {
@@ -30,9 +30,8 @@ func TestClientConnectorCreateOk(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createConnectorOkJson))
-		remoteNetworkID := graphql.ID("test")
 
-		connector, err := client.createConnector(context.Background(), remoteNetworkID)
+		connector, err := client.createConnector(context.Background(), "test")
 
 		assert.Nil(t, err)
 		assert.EqualValues(t, "test-id", connector.ID)
@@ -60,10 +59,8 @@ func TestClientConnectorUpdateOk(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, updateConnectorOkJson))
-		connectorId := graphql.ID("test-id")
-		connectorName := graphql.String("test-name")
 
-		err := client.updateConnector(context.Background(), connectorId, connectorName)
+		err := client.updateConnector(context.Background(), "test-id", "test-name")
 
 		assert.Nil(t, err)
 	})
@@ -86,7 +83,7 @@ func TestClientConnectorDeleteOk(t *testing.T) {
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, deleteConnectorOkJson))
 
-		err := client.deleteConnector(context.Background(), graphql.ID("test"))
+		err := client.deleteConnector(context.Background(), "test")
 
 		assert.NoError(t, err)
 	})
@@ -109,9 +106,8 @@ func TestClientConnectorCreateError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createNetworkErrorJson))
-		remoteNetworkID := graphql.ID("test")
 
-		remoteNetwork, err := client.createConnector(context.Background(), remoteNetworkID)
+		remoteNetwork, err := client.createConnector(context.Background(), "test")
 
 		assert.EqualError(t, err, "failed to create connector: error_1")
 		assert.Nil(t, remoteNetwork)
@@ -135,12 +131,11 @@ func TestClientConnectorUpdateError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createNetworkOkJson))
-		connectorId := graphql.ID("test-id")
-		connectorName := graphql.String("test-name")
+		connectorId := "test-id"
 
-		err := client.updateConnector(context.Background(), connectorId, connectorName)
+		err := client.updateConnector(context.Background(), connectorId, "test-name")
 
-		assert.EqualError(t, err, "failed to update connector with id test-id: error_1")
+		assert.EqualError(t, err, fmt.Sprintf("failed to update connector with id %s: error_1", connectorId))
 	})
 }
 
@@ -161,10 +156,8 @@ func TestClientConnectorUpdateErrorWhenIdEmpty(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createNetworkOkJson))
-		connectorId := graphql.ID("")
-		connectorName := graphql.String("")
 
-		err := client.updateConnector(context.Background(), connectorId, connectorName)
+		err := client.updateConnector(context.Background(), "", "")
 
 		assert.EqualError(t, err, "failed to update connector: network id is empty")
 	})
@@ -180,9 +173,8 @@ func TestClientConnectorEmptyNetworkIDCreateError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createNetworkOkJson))
-		remoteNetworkID := graphql.ID("")
 
-		remoteNetwork, err := client.createConnector(context.Background(), remoteNetworkID)
+		remoteNetwork, err := client.createConnector(context.Background(), "")
 
 		assert.EqualError(t, err, "failed to create connector: network id is empty")
 		assert.Nil(t, remoteNetwork)
@@ -206,11 +198,11 @@ func TestClientConnectorDeleteError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, deleteConnectorOkJson))
-		connectorId := graphql.ID("test")
+		connectorId := "test"
 
 		err := client.deleteConnector(context.Background(), connectorId)
 
-		assert.EqualError(t, err, "failed to delete connector with id test: error_1")
+		assert.EqualError(t, err, fmt.Sprintf("failed to delete connector with id %s: error_1", connectorId))
 	})
 }
 
@@ -228,12 +220,12 @@ func TestClientConnectorReadError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, readNetworkOkJson))
-		connectorId := graphql.ID("test")
+		connectorId := "test"
 
 		connector, err := client.readConnector(context.Background(), connectorId)
 
 		assert.Nil(t, connector)
-		assert.EqualError(t, err, "failed to read connector with id test")
+		assert.EqualError(t, err, fmt.Sprintf("failed to read connector with id %s", connectorId))
 	})
 }
 
@@ -264,9 +256,8 @@ func TestClientConnectorEmptyReadError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, readConnectorOkJson))
-		connectorId := graphql.ID("")
 
-		connector, err := client.readConnector(context.Background(), connectorId)
+		connector, err := client.readConnector(context.Background(), "")
 
 		assert.Nil(t, connector)
 		assert.EqualError(t, err, "failed to read connector: id is empty")
@@ -283,9 +274,8 @@ func TestClientConnectorEmptyDeleteError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, deleteConnectorOkJson))
-		connectorId := graphql.ID("")
 
-		err := client.deleteConnector(context.Background(), connectorId)
+		err := client.deleteConnector(context.Background(), "")
 
 		assert.EqualError(t, err, "failed to delete connector: id is empty")
 	})
@@ -371,11 +361,11 @@ func TestClientConnectorUpdateRequestError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewErrorResponder(errors.New("error_1")))
-		connectorId := graphql.ID("test")
+		connectorId := "test"
 
 		err := client.updateConnector(context.Background(), connectorId, "new name")
 
-		assert.EqualError(t, err, "failed to update connector with id test: Post \"https://test.twindev.com/api/graphql/\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to update connector with id %s: Post "%s": error_1`, connectorId, client.GraphqlServerURL))
 	})
 }
 
@@ -386,11 +376,11 @@ func TestClientConnectorDeleteRequestError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewErrorResponder(errors.New("error_1")))
-		connectorId := graphql.ID("test")
+		connectorId := "test"
 
 		err := client.deleteConnector(context.Background(), connectorId)
 
-		assert.EqualError(t, err, "failed to delete connector with id test: Post \"https://test.twindev.com/api/graphql/\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to delete connector with id %s: Post "%s": error_1`, connectorId, client.GraphqlServerURL))
 	})
 }
 
@@ -401,11 +391,10 @@ func TestClientConnectorCreateRequestError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewErrorResponder(errors.New("error_1")))
-		remoteNetworkID := graphql.ID("test")
 
-		remoteNetwork, err := client.createConnector(context.Background(), remoteNetworkID)
+		remoteNetwork, err := client.createConnector(context.Background(), "test")
 
-		assert.EqualError(t, err, "failed to create connector: Post \"https://test.twindev.com/api/graphql/\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to create connector: Post "%s": error_1`, client.GraphqlServerURL))
 		assert.Nil(t, remoteNetwork)
 	})
 }
@@ -417,11 +406,11 @@ func TestClientConnectorReadRequestError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewErrorResponder(errors.New("error_1")))
-		connectorId := graphql.ID("test")
+		connectorId := "test"
 
 		connector, err := client.readConnector(context.Background(), connectorId)
 
 		assert.Nil(t, connector)
-		assert.EqualError(t, err, "failed to read connector with id test: Post \"https://test.twindev.com/api/graphql/\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to read connector with id %s: Post "%s": error_1`, connectorId, client.GraphqlServerURL))
 	})
 }

--- a/twingate/client_connector_tokens_test.go
+++ b/twingate/client_connector_tokens_test.go
@@ -3,6 +3,7 @@ package twingate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -81,7 +82,7 @@ func TestClientConnectorTokensVerify401Error(t *testing.T) {
 
 	err := client.verifyConnectorTokens(context.Background(), refreshToken, accessToken)
 
-	assert.EqualError(t, err, "failed to verify connector tokens: request https://test.twindev.com/api/v1/access_node/refresh failed, status 401, body {}")
+	assert.EqualError(t, err, fmt.Sprintf("failed to verify connector tokens: request %s failed, status 401, body {}", apiURL))
 }
 
 func TestClientConnectorTokensVerifyRequestError(t *testing.T) {
@@ -100,7 +101,7 @@ func TestClientConnectorTokensVerifyRequestError(t *testing.T) {
 		})
 
 	err := client.verifyConnectorTokens(context.Background(), refreshToken, accessToken)
-	assert.EqualError(t, err, "failed to verify connector tokens: can't execute http request: Post \"https://test.twindev.com/api/v1/access_node/refresh\": error")
+	assert.EqualError(t, err, fmt.Sprintf(`failed to verify connector tokens: can't execute http request: Post "%s": error`, apiURL))
 }
 
 func TestClientConnectorCreateTokensError(t *testing.T) {
@@ -123,7 +124,7 @@ func TestClientConnectorCreateTokensError(t *testing.T) {
 	}
 	err := client.generateConnectorTokens(context.Background(), connector)
 
-	assert.EqualError(t, err, "failed to generate connector tokens with id test-id: error_1")
+	assert.EqualError(t, err, fmt.Sprintf(`failed to generate connector tokens with id %v: error_1`, connector.ID))
 }
 
 func TestClientConnectorTokensCreateRequestError(t *testing.T) {
@@ -137,5 +138,5 @@ func TestClientConnectorTokensCreateRequestError(t *testing.T) {
 	}
 
 	err := client.generateConnectorTokens(context.Background(), connector)
-	assert.EqualError(t, err, "failed to generate connector tokens: Post \"https://test.twindev.com/api/graphql/\": error_1")
+	assert.EqualError(t, err, fmt.Sprintf(`failed to generate connector tokens: Post "%s": error_1`, client.GraphqlServerURL))
 }

--- a/twingate/client_remote_network.go
+++ b/twingate/client_remote_network.go
@@ -22,7 +22,7 @@ type createRemoteNetworkQuery struct {
 	} `graphql:"remoteNetworkCreate(name: $name, isActive: $isActive)"`
 }
 
-func (client *Client) createRemoteNetwork(ctx context.Context, remoteNetworkName graphql.String) (*remoteNetwork, error) {
+func (client *Client) createRemoteNetwork(ctx context.Context, remoteNetworkName string) (*remoteNetwork, error) {
 	if remoteNetworkName == "" {
 		return nil, NewAPIError(ErrGraphqlNetworkNameIsEmpty, "create", remoteNetworkResourceName)
 	}
@@ -30,7 +30,7 @@ func (client *Client) createRemoteNetwork(ctx context.Context, remoteNetworkName
 	response := createRemoteNetworkQuery{}
 
 	variables := map[string]interface{}{
-		"name":     remoteNetworkName,
+		"name":     graphql.String(remoteNetworkName),
 		"isActive": graphql.Boolean(true),
 	}
 	err := client.GraphqlClient.NamedMutate(ctx, "createRemoteNetwork", &response, variables)
@@ -80,13 +80,13 @@ type readRemoteNetworkQuery struct {
 	} `graphql:"remoteNetwork(id: $id)"`
 }
 
-func (client *Client) readRemoteNetwork(ctx context.Context, remoteNetworkID graphql.ID) (*remoteNetwork, error) {
-	if remoteNetworkID.(string) == "" {
+func (client *Client) readRemoteNetwork(ctx context.Context, remoteNetworkID string) (*remoteNetwork, error) {
+	if remoteNetworkID == "" {
 		return nil, NewAPIError(ErrGraphqlNetworkIDIsEmpty, "read", remoteNetworkResourceName)
 	}
 
 	variables := map[string]interface{}{
-		"id": remoteNetworkID,
+		"id": graphql.ID(remoteNetworkID),
 	}
 
 	response := readRemoteNetworkQuery{}
@@ -110,10 +110,10 @@ type updateRemoteNetworkQuery struct {
 	RemoteNetworkUpdate *OkError `graphql:"remoteNetworkUpdate(id: $id, name: $name)"`
 }
 
-func (client *Client) updateRemoteNetwork(ctx context.Context, remoteNetworkID graphql.ID, remoteNetworkName graphql.String) error {
+func (client *Client) updateRemoteNetwork(ctx context.Context, remoteNetworkID, remoteNetworkName string) error {
 	variables := map[string]interface{}{
-		"id":   remoteNetworkID,
-		"name": remoteNetworkName,
+		"id":   graphql.ID(remoteNetworkID),
+		"name": graphql.String(remoteNetworkName),
 	}
 
 	response := updateRemoteNetworkQuery{}
@@ -134,13 +134,13 @@ type deleteRemoteNetworkQuery struct {
 	RemoteNetworkDelete *OkError `graphql:"remoteNetworkDelete(id: $id)"`
 }
 
-func (client *Client) deleteRemoteNetwork(ctx context.Context, remoteNetworkID graphql.ID) error {
-	if remoteNetworkID.(string) == "" {
+func (client *Client) deleteRemoteNetwork(ctx context.Context, remoteNetworkID string) error {
+	if remoteNetworkID == "" {
 		return NewAPIError(ErrGraphqlNetworkIDIsEmpty, "delete", remoteNetworkResourceName)
 	}
 
 	variables := map[string]interface{}{
-		"id": remoteNetworkID,
+		"id": graphql.ID(remoteNetworkID),
 	}
 
 	response := deleteRemoteNetworkQuery{}

--- a/twingate/client_remote_network_test.go
+++ b/twingate/client_remote_network_test.go
@@ -3,12 +3,12 @@ package twingate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"github.com/twingate/go-graphql-client"
 )
 
 func TestClientRemoteNetworkCreateOk(t *testing.T) {
@@ -30,9 +30,8 @@ func TestClientRemoteNetworkCreateOk(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createNetworkOkJson))
-		remoteNetworkName := graphql.String("test")
 
-		remoteNetwork, err := client.createRemoteNetwork(context.Background(), remoteNetworkName)
+		remoteNetwork, err := client.createRemoteNetwork(context.Background(), "test")
 
 		assert.Nil(t, err)
 		assert.EqualValues(t, "test-id", remoteNetwork.ID)
@@ -55,9 +54,8 @@ func TestClientRemoteNetworkCreateError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createNetworkOkJson))
-		remoteNetworkName := graphql.String("test")
 
-		remoteNetwork, err := client.createRemoteNetwork(context.Background(), remoteNetworkName)
+		remoteNetwork, err := client.createRemoteNetwork(context.Background(), "test")
 
 		assert.EqualError(t, err, "failed to create remote network: error_1")
 		assert.Nil(t, remoteNetwork)
@@ -85,11 +83,9 @@ func TestClientRemoteNetworkCreateRequestError(t *testing.T) {
 				return resp, errors.New("error_1")
 			})
 
-		remoteNetworkName := graphql.String("test")
+		remoteNetwork, err := client.createRemoteNetwork(context.Background(), "test")
 
-		remoteNetwork, err := client.createRemoteNetwork(context.Background(), remoteNetworkName)
-
-		assert.EqualError(t, err, "failed to create remote network: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to create remote network: Post "%s": error_1`, client.GraphqlServerURL))
 		assert.Nil(t, remoteNetwork)
 	})
 }
@@ -110,9 +106,8 @@ func TestClientRemoteNetworkUpdateError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, updateNetworkOkJson))
-		remoteNetworkName := graphql.String("test")
-		remoteNetworkId := graphql.ID("id")
-		err := client.updateRemoteNetwork(context.Background(), remoteNetworkId, remoteNetworkName)
+
+		err := client.updateRemoteNetwork(context.Background(), "id", "test")
 
 		assert.EqualError(t, err, "failed to update remote network with id id: error_1")
 	})
@@ -138,11 +133,9 @@ func TestClientRemoteNetworkUpdateRequestError(t *testing.T) {
 				return resp, errors.New("error_1")
 			})
 
-		remoteNetworkName := graphql.String("test")
-		remoteNetworkId := graphql.ID("id")
-		err := client.updateRemoteNetwork(context.Background(), remoteNetworkId, remoteNetworkName)
+		err := client.updateRemoteNetwork(context.Background(), "id", "test")
 
-		assert.EqualError(t, err, "failed to update remote network with id id: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to update remote network with id id: Post "%s": error_1`, client.GraphqlServerURL))
 	})
 }
 
@@ -159,9 +152,8 @@ func TestClientRemoteNetworkReadError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, readNetworkOkJson))
-		remoteNetworkId := graphql.ID("id")
 
-		remoteNetwork, err := client.readRemoteNetwork(context.Background(), remoteNetworkId)
+		remoteNetwork, err := client.readRemoteNetwork(context.Background(), "id")
 
 		assert.Nil(t, remoteNetwork)
 		assert.EqualError(t, err, "failed to read remote network with id id")
@@ -184,12 +176,11 @@ func TestClientRemoteNetworkReadRequestError(t *testing.T) {
 				resp := httpmock.NewStringResponse(200, readNetworkOkJson)
 				return resp, errors.New("error_1")
 			})
-		remoteNetworkId := graphql.ID("id")
 
-		remoteNetwork, err := client.readRemoteNetwork(context.Background(), remoteNetworkId)
+		remoteNetwork, err := client.readRemoteNetwork(context.Background(), "id")
 
 		assert.Nil(t, remoteNetwork)
-		assert.EqualError(t, err, "failed to read remote network with id id: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to read remote network with id id: Post "%s": error_1`, client.GraphqlServerURL))
 	})
 }
 
@@ -206,9 +197,8 @@ func TestClientCreateEmptyRemoteNetworkError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, readNetworkOkJson))
-		remoteNetworkName := graphql.String("")
 
-		remoteNetwork, err := client.createRemoteNetwork(context.Background(), remoteNetworkName)
+		remoteNetwork, err := client.createRemoteNetwork(context.Background(), "")
 
 		assert.EqualError(t, err, "failed to create remote network: network name is empty")
 		assert.Nil(t, remoteNetwork)
@@ -228,9 +218,8 @@ func TestClientReadEmptyRemoteNetworkError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, readNetworkOkJson))
-		remoteNetworkId := graphql.ID("")
 
-		remoteNetwork, err := client.readRemoteNetwork(context.Background(), remoteNetworkId)
+		remoteNetwork, err := client.readRemoteNetwork(context.Background(), "")
 
 		assert.EqualError(t, err, "failed to read remote network: network id is empty")
 		assert.Nil(t, remoteNetwork)
@@ -250,9 +239,8 @@ func TestClientDeleteEmptyRemoteNetworkError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, readNetworkOkJson))
-		remoteNetworkId := graphql.ID("")
 
-		err := client.deleteRemoteNetwork(context.Background(), remoteNetworkId)
+		err := client.deleteRemoteNetwork(context.Background(), "")
 
 		assert.EqualError(t, err, "failed to delete remote network: network id is empty")
 	})

--- a/twingate/client_resource.go
+++ b/twingate/client_resource.go
@@ -232,14 +232,14 @@ type readResourceQuery struct {
 	} `graphql:"resource(id: $id)"`
 }
 
-func (client *Client) readResource(ctx context.Context, resourceID graphql.ID) (*Resource, error) {
-	if resourceID.(string) == "" {
+func (client *Client) readResource(ctx context.Context, resourceID string) (*Resource, error) {
+	if resourceID == "" {
 		return nil, NewAPIError(ErrGraphqlIDIsEmpty, "read", resourceResourceName)
 	}
 
 	response := readResourceQuery{}
 	variables := map[string]interface{}{
-		"id":    resourceID,
+		"id":    graphql.ID(resourceID),
 		"first": graphql.Int(readResourceQueryGroupsSize),
 	}
 
@@ -325,15 +325,15 @@ type deleteResourceQuery struct {
 	ResourceDelete *OkError `graphql:"resourceDelete(id: $id)"`
 }
 
-func (client *Client) deleteResource(ctx context.Context, resourceID graphql.ID) error {
-	if resourceID.(string) == "" {
+func (client *Client) deleteResource(ctx context.Context, resourceID string) error {
+	if resourceID == "" {
 		return NewAPIError(ErrGraphqlIDIsEmpty, "delete", resourceResourceName)
 	}
 
 	response := deleteResourceQuery{}
 
 	variables := map[string]interface{}{
-		"id": resourceID,
+		"id": graphql.ID(resourceID),
 	}
 
 	err := client.GraphqlClient.NamedMutate(ctx, "updateResource", &response, variables)

--- a/twingate/client_resource_test.go
+++ b/twingate/client_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -190,7 +191,7 @@ func TestClientResourceCreateRequestError(t *testing.T) {
 
 		err := client.createResource(context.Background(), resource)
 
-		assert.EqualError(t, err, "failed to create resource: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to create resource: Post "%s": error_1`, client.GraphqlServerURL))
 	})
 }
 
@@ -328,10 +329,11 @@ func TestClientResourceReadTooManyGroups(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createResourceOkJson))
+		resourceID := "resource1"
 
-		resource, err := client.readResource(context.Background(), "resource1")
+		resource, err := client.readResource(context.Background(), resourceID)
 		assert.Nil(t, resource)
-		assert.EqualError(t, err, "failed to read resource with id resource1: provider does not support more than 50 groups per resource")
+		assert.EqualError(t, err, fmt.Sprintf("failed to read resource with id %s: provider does not support more than 50 groups per resource", resourceID))
 	})
 }
 
@@ -348,11 +350,12 @@ func TestClientResourceReadError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createResourceErrorJson))
+		resourceID := "resource1"
 
-		resource, err := client.readResource(context.Background(), "resource1")
+		resource, err := client.readResource(context.Background(), resourceID)
 
 		assert.Nil(t, resource)
-		assert.EqualError(t, err, "failed to read resource with id resource1")
+		assert.EqualError(t, err, fmt.Sprintf("failed to read resource with id %s", resourceID))
 	})
 }
 
@@ -366,7 +369,7 @@ func TestClientResourceEmptyReadError(t *testing.T) {
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createResourceErrorJson))
 
-		resource, err := client.readResource(context.Background(), graphql.ID(""))
+		resource, err := client.readResource(context.Background(), "")
 
 		assert.Nil(t, resource)
 		assert.EqualError(t, err, "failed to read resource: id is empty")
@@ -380,11 +383,12 @@ func TestClientResourceReadRequestError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewErrorResponder(errors.New("error_1")))
+		resourceID := "test-id"
 
-		resource, err := client.readResource(context.Background(), graphql.ID("test-id"))
+		resource, err := client.readResource(context.Background(), resourceID)
 
 		assert.Nil(t, resource)
-		assert.EqualError(t, err, "failed to read resource with id test-id: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to read resource with id %s: Post "%s": error_1`, resourceID, client.GraphqlServerURL))
 	})
 }
 
@@ -447,7 +451,7 @@ func TestClientResourceUpdateRequestError(t *testing.T) {
 
 		err := client.updateResource(context.Background(), resource)
 
-		assert.EqualError(t, err, "failed to update resource with id test: Post \"https://test.twindev.com/api/graphql/\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to update resource with id %v: Post "%s": error_1`, resource.ID, client.GraphqlServerURL))
 	})
 }
 
@@ -490,10 +494,11 @@ func TestClientResourceDeleteError(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createResourceDeleteErrorJson))
+		resourceID := "resource1"
 
-		err := client.deleteResource(context.Background(), "resource1")
+		err := client.deleteResource(context.Background(), resourceID)
 
-		assert.EqualError(t, err, "failed to delete resource with id resource1: cant delete resource")
+		assert.EqualError(t, err, fmt.Sprintf("failed to delete resource with id %s: cant delete resource", resourceID))
 	})
 }
 
@@ -516,10 +521,11 @@ func TestClientResourceDeleteRequestError(t *testing.T) {
 				resp := httpmock.NewStringResponse(200, createResourceDeleteErrorJson)
 				return resp, errors.New("error_1")
 			})
+		resourceID := "resource1"
 
-		err := client.deleteResource(context.Background(), "resource1")
+		err := client.deleteResource(context.Background(), resourceID)
 
-		assert.EqualError(t, err, "failed to delete resource with id resource1: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to delete resource with id %s: Post "%s": error_1`, resourceID, client.GraphqlServerURL))
 	})
 }
 
@@ -533,7 +539,7 @@ func TestClientResourceEmptyDeleteError(t *testing.T) {
 		httpmock.RegisterResponder("POST", client.GraphqlServerURL,
 			httpmock.NewStringResponder(200, createResourceDeleteErrorJson))
 
-		err := client.deleteResource(context.Background(), graphql.ID(""))
+		err := client.deleteResource(context.Background(), "")
 
 		assert.EqualError(t, err, "failed to delete resource: id is empty")
 	})
@@ -618,6 +624,6 @@ func TestClientResourcesReadRequestError(t *testing.T) {
 		resources, err := client.readResources(context.Background())
 
 		assert.Nil(t, resources)
-		assert.EqualError(t, err, "failed to read resource with id All: Post \""+client.GraphqlServerURL+"\": error_1")
+		assert.EqualError(t, err, fmt.Sprintf(`failed to read resource with id All: Post "%s": error_1`, client.GraphqlServerURL))
 	})
 }

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/twingate/go-graphql-client"
 )
 
 func resourceConnector() *schema.Resource {
@@ -73,7 +72,7 @@ func resourceConnectorUpdate(ctx context.Context, resourceData *schema.ResourceD
 		connectorID := resourceData.Id()
 		log.Printf("[INFO] Updating name of connector id %s", connectorID)
 
-		if err := client.updateConnector(ctx, graphql.ID(connectorID), graphql.String(connectorName)); err != nil {
+		if err := client.updateConnector(ctx, connectorID, connectorName); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -92,7 +91,7 @@ func resourceConnectorDelete(ctx context.Context, resourceData *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[INFO] Destroyed connector id %s", resourceData.Id())
+	log.Printf("[INFO] Destroyed connector id %s", connectorID)
 
 	return diags
 }

--- a/twingate/resource_connector_sweepers_test.go
+++ b/twingate/resource_connector_sweepers_test.go
@@ -17,7 +17,7 @@ func init() {
 
 func testSweepTwingateConnector(tenant string) error {
 	resourceName := "twingate_connector"
-	log.Printf("\"[INFO][SWEEPER_LOG] Starting sweeper for %s\"", resourceName)
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
 	client, err := sharedClient(tenant)
 	if err != nil {
 		log.Printf("[ERROR][SWEEPER_LOG] error getting client: %s", err)

--- a/twingate/resource_remote_network.go
+++ b/twingate/resource_remote_network.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/twingate/go-graphql-client"
 )
 
 func resourceRemoteNetwork() *schema.Resource {
@@ -41,7 +40,7 @@ func resourceRemoteNetworkCreate(ctx context.Context, resourceData *schema.Resou
 	var diags diag.Diagnostics
 
 	remoteNetworkName := resourceData.Get("name").(string)
-	remoteNetwork, err := client.createRemoteNetwork(ctx, graphql.String(remoteNetworkName))
+	remoteNetwork, err := client.createRemoteNetwork(ctx, remoteNetworkName)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -63,7 +62,7 @@ func resourceRemoteNetworkUpdate(ctx context.Context, resourceData *schema.Resou
 		remoteNetworkID := resourceData.Id()
 		log.Printf("[INFO] Updating remote network id %s", remoteNetworkID)
 
-		if err := client.updateRemoteNetwork(ctx, graphql.ID(remoteNetworkID), graphql.String(remoteNetworkName)); err != nil {
+		if err := client.updateRemoteNetwork(ctx, remoteNetworkID, remoteNetworkName); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -83,7 +82,7 @@ func resourceRemoteNetworkDelete(ctx context.Context, resourceData *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[INFO] Deleted remote network id %s", resourceData.Id())
+	log.Printf("[INFO] Deleted remote network id %s", remoteNetworkID)
 
 	return diags
 }
@@ -95,7 +94,7 @@ func resourceRemoteNetworkRead(ctx context.Context, resourceData *schema.Resourc
 
 	remoteNetworkID := resourceData.Id()
 
-	log.Printf("[INFO] Reading remote network id %s", resourceData.Id())
+	log.Printf("[INFO] Reading remote network id %s", remoteNetworkID)
 
 	remoteNetwork, err := client.readRemoteNetwork(ctx, remoteNetworkID)
 

--- a/twingate/resource_remote_network_sweepers_test.go
+++ b/twingate/resource_remote_network_sweepers_test.go
@@ -2,11 +2,11 @@ package twingate
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/twingate/go-graphql-client"
 )
 
 func init() {
@@ -38,11 +38,11 @@ func testSweepTwingateRemoteNetwork(tenant string) error {
 		return nil
 	}
 
-	var testNetworks = make([]graphql.ID, 0)
+	var testNetworks = make([]string, 0)
 
 	for _, elem := range networkMap {
 		if strings.HasPrefix(string(elem.Name), "tf-acc") {
-			testNetworks = append(testNetworks, elem.ID)
+			testNetworks = append(testNetworks, fmt.Sprintf("%v", elem.ID))
 		}
 	}
 


### PR DESCRIPTION
## Changes
- Changed internal client uses in provider, so from terraform provider we don't need to use graphql types
