### PR TITLE
Remove CHANGELOG.md as its not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.0.1 (Unreleased)
-
-* Remote network support - resource


### PR DESCRIPTION
We’re tracking changes via description of Github Releases

