### PR TITLE
Not allow change remote_network_id for existing connector

### DIFF
--- a/examples/resources/twingate_connector/resource.tf
+++ b/examples/resources/twingate_connector/resource.tf
@@ -8,5 +8,5 @@ resource "twingate_remote_network" "aws_network" {
 }
 
 resource "twingate_connector" "aws_connector" {
-  remote_network_id = "twingate_remote_network.aws_network.id"
+  remote_network_id = twingate_remote_network.aws_network.id
 }

--- a/examples/resources/twingate_connector/resource.tf
+++ b/examples/resources/twingate_connector/resource.tf
@@ -1,13 +1,12 @@
 provider "twingate" {
-#  api_token = "1234567890abcdef"
-#  network   = "mynetwork"
+  api_token = "1234567890abcdef"
+  network   = "mynetwork"
 }
 
 resource "twingate_remote_network" "aws_network" {
-  name = "tf-acc-8039014946868982466"
+  name = "aws_remote_network"
 }
 
 resource "twingate_connector" "aws_connector" {
-  remote_network_id = "UmVtb3RlTmV0d29yazo0MDA2NA=="
-  name = "updated connector name"
+  remote_network_id = "twingate_remote_network.aws_network.id"
 }

--- a/examples/resources/twingate_connector/resource.tf
+++ b/examples/resources/twingate_connector/resource.tf
@@ -1,12 +1,13 @@
 provider "twingate" {
-  api_token = "1234567890abcdef"
-  network   = "mynetwork"
+#  api_token = "1234567890abcdef"
+#  network   = "mynetwork"
 }
 
 resource "twingate_remote_network" "aws_network" {
-  name = "aws_remote_network"
+  name = "tf-acc-8039014946868982466"
 }
 
 resource "twingate_connector" "aws_connector" {
-  remote_network_id = twingate_remote_network.aws_network.id
+  remote_network_id = "UmVtb3RlTmV0d29yazo0MDA2NA=="
+  name = "updated connector name"
 }

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.16
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/jarcoal/httpmock v1.2.0
-	github.com/klauspost/compress v1.11.2
+	github.com/jarcoal/httpmock v1.1.0
+	github.com/klauspost/compress v1.11.2 // indirect
 	github.com/stretchr/testify v1.7.1
 	github.com/twingate/go-graphql-client v0.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
-github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
+github.com/jarcoal/httpmock v1.1.0 h1:F47ChZj1Y2zFsCXxNkBPwNNKnAyOATcdQibk0qEdVCE=
+github.com/jarcoal/httpmock v1.1.0/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -203,8 +203,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/maxatome/go-testdeep v1.11.0 h1:Tgh5efyCYyJFGUYiT0qxBSIDeXw0F5zSoatlou685kk=
-github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+var ErrNotAllowChangeRemoteNetworkID = errors.New("not allowed to change remote_network_id")
+
 func resourceConnector() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Connectors provide connectivity to Remote Networks. This resource type will create the Connector in the Twingate Admin Console, but in order to successfully deploy it, you must also generate Connector tokens that authenticate the Connector with Twingate. For more information, see Twingate's [documentation](https://docs.twingate.com/docs/understanding-access-nodes).",
@@ -22,7 +24,7 @@ func resourceConnector() *schema.Resource {
 			oldVal, _ := d.GetChange(key)
 			old := oldVal.(string)
 			if old != "" && d.HasChange(key) {
-				return errors.New("not allowed to change remote_network_id")
+				return ErrNotAllowChangeRemoteNetworkID
 			}
 
 			return nil

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ErrNotAllowChangeRemoteNetworkID = errors.New("connectors cant move between networks, and either create a new connector or destroy and recreate the existing one")
+var ErrNotAllowChangeRemoteNetworkID = errors.New("connectors cant move between networks, either create a new connector or destroy and recreate the existing one")
 
 func resourceConnector() *schema.Resource {
 	return &schema.Resource{

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ErrNotAllowChangeRemoteNetworkID = errors.New("Connectors cannot be moved between Remote Networks. You must either create a new Connector or destroy and recreate the existing one.")
+var ErrNotAllowChangeRemoteNetworkID = errors.New("connectors cannot be moved between Remote Networks: you must either create a new Connector or destroy and recreate the existing one")
 
 func resourceConnector() *schema.Resource {
 	return &schema.Resource{

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -2,6 +2,7 @@ package twingate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -16,6 +17,16 @@ func resourceConnector() *schema.Resource {
 		ReadContext:   resourceConnectorRead,
 		DeleteContext: resourceConnectorDelete,
 		UpdateContext: resourceConnectorUpdate,
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+			const key = "remote_network_id"
+			oldVal, _ := d.GetChange(key)
+			old := oldVal.(string)
+			if old != "" && d.HasChange(key) {
+				return errors.New("not allowed to change remote_network_id")
+			}
+
+			return nil
+		},
 
 		Schema: map[string]*schema.Schema{
 			// required

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ErrNotAllowChangeRemoteNetworkID = errors.New("connectors cant move between networks, either create a new connector or destroy and recreate the existing one")
+var ErrNotAllowChangeRemoteNetworkID = errors.New("Connectors cannot be moved between Remote Networks. You must either create a new Connector or destroy and recreate the existing one.")
 
 func resourceConnector() *schema.Resource {
 	return &schema.Resource{

--- a/twingate/resource_connector.go
+++ b/twingate/resource_connector.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ErrNotAllowChangeRemoteNetworkID = errors.New("not allowed to change remote_network_id")
+var ErrNotAllowChangeRemoteNetworkID = errors.New("connectors cant move between networks, and either create a new connector or destroy and recreate the existing one")
 
 func resourceConnector() *schema.Resource {
 	return &schema.Resource{

--- a/twingate/resource_connector_test.go
+++ b/twingate/resource_connector_test.go
@@ -162,7 +162,7 @@ func TestAccRemoteConnector_notAllowedToChangeRemoteNetworkId(t *testing.T) {
 				},
 				{
 					Config:      testTwingateConnectorWithAnotherNetwork(remoteNetworkName1),
-					ExpectError: regexp.MustCompile("not allowed to change remote_network_id"),
+					ExpectError: regexp.MustCompile(ErrNotAllowChangeRemoteNetworkID.Error()),
 				},
 			},
 		})

--- a/twingate/resource_connector_test.go
+++ b/twingate/resource_connector_test.go
@@ -77,6 +77,17 @@ func testTwingateConnector(remoteNetworkName string) string {
 	`, remoteNetworkName)
 }
 
+func testTwingateConnectorWithAnotherNetwork(remoteNetworkName string) string {
+	return fmt.Sprintf(`
+	resource "twingate_remote_network" "test1" {
+	  name = "%s"
+	}
+	resource "twingate_connector" "test" {
+	  remote_network_id = twingate_remote_network.test1.id
+	}
+	`, remoteNetworkName)
+}
+
 func testTwingateConnectorWithCustomName(remoteNetworkName string, connectorName string) string {
 	return fmt.Sprintf(`
 	resource "twingate_remote_network" "test" {
@@ -129,4 +140,31 @@ func testAccCheckTwingateConnectorExists(connectorResource, remoteNetworkResourc
 		}
 		return nil
 	}
+}
+
+func TestAccRemoteConnector_notAllowedToChangeRemoteNetworkId(t *testing.T) {
+	t.Run("Test Twingate Resource : Acc Remote Connector - should fail on remote_network_id update", func(t *testing.T) {
+		remoteNetworkName := acctest.RandomWithPrefix(testPrefixName)
+		remoteNetworkName1 := acctest.RandomWithPrefix(testPrefixName)
+		connectorResource := "twingate_connector.test"
+		remoteNetworkResource := "twingate_remote_network.test"
+
+		resource.Test(t, resource.TestCase{
+			ProviderFactories: testAccProviderFactories,
+			PreCheck:          func() { testAccPreCheck(t) },
+			CheckDestroy:      testAccCheckTwingateConnectorDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testTwingateConnector(remoteNetworkName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckTwingateConnectorExists(connectorResource, remoteNetworkResource),
+					),
+				},
+				{
+					Config:      testTwingateConnectorWithAnotherNetwork(remoteNetworkName1),
+					ExpectError: regexp.MustCompile("not allowed to change remote_network_id"),
+				},
+			},
+		})
+	})
 }


### PR DESCRIPTION
Github Issue: https://github.com/Twingate/terraform-provider-twingate/issues/79

## Changes
- added fix to not allow change remote_network_id for existing connector
