### PR TITLE
Switch to crazy-max/ghaction-import-gpg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
Change the `Import GPG Key` task to use `crazy-max/ghaction-import-gpg@v5` based on hashicorp recommendation:


<img width="1157" alt="Screen Shot 2022-07-19 at 9 52 34 AM" src="https://user-images.githubusercontent.com/205185/179806355-d95b11d8-22cf-47f2-ab8b-ee00a61ab101.png">

