### PR TITLE
CI: Dont run acceptance tests from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
     name: Matrix Acceptance Tests
     needs: build
     runs-on: ubuntu-latest
-    environment: acceptance-tests
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
   push:
     paths-ignore:
       - 'README.md'
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ on:
     branches:
       - main
 
+# Ensures only 1 action runs per PR and previous is canceled on new trigger
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
     name: Matrix Acceptance Tests
     needs: build
     runs-on: ubuntu-latest
+    if: "!github.event.pull_request.head.repo.fork"
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ name: CI
 permissions: read-all
 on:
   pull_request:
-     paths-ignore:
+    branches:
+      - main
+    paths-ignore:
        - 'README.md'
 
   push:

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -3,6 +3,12 @@ permissions: read-all
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
+
+# Ensures only 1 action runs per PR and previous is canceled on new trigger
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-pr:
     name: "Verify PR title and desc"

--- a/Makefile
+++ b/Makefile
@@ -90,4 +90,4 @@ docs: doc-tools
 .PHONY: tools
 tools:
 	@echo "==> installing required tools ..."
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3


### PR DESCRIPTION
# Changeas
- Downgraded `lint` as new version has breaking changes. We already have a separate PR to upgrade it - https://github.com/Twingate/terraform-provider-twingate/pull/170
- Removed acceptance-tests from forked PRs
- Added concurrency settings so that pushing a change cancels previous running build
- 