### PR TITLE
Update lint rules

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -3,12 +3,12 @@
 page_title: "twingate_user Data Source - terraform-provider-twingate"
 subcategory: ""
 description: |-
-  Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's documentation https://docs.twingate.com/docs/users.
+  Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see Twingate's documentation https://docs.twingate.com/docs/users.
 ---
 
 # twingate_user (Data Source)
 
-Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's [documentation](https://docs.twingate.com/docs/users).
+Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see Twingate's [documentation](https://docs.twingate.com/docs/users).
 
 ## Example Usage
 

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -3,12 +3,12 @@
 page_title: "twingate_users Data Source - terraform-provider-twingate"
 subcategory: ""
 description: |-
-  Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's documentation https://docs.twingate.com/docs/users.
+  Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see Twingate's documentation https://docs.twingate.com/docs/users.
 ---
 
 # twingate_users (Data Source)
 
-Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's [documentation](https://docs.twingate.com/docs/users).
+Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see Twingate's [documentation](https://docs.twingate.com/docs/users).
 
 ## Example Usage
 

--- a/golangci.yml
+++ b/golangci.yml
@@ -42,14 +42,10 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - maligned
     - lll
-    - scopelint
     - gofumpt
     - exhaustivestruct
-    - interfacer
     - forcetypeassert
-    - golint
     - exhaustruct
   disable-all: false
   fast: false

--- a/golangci.yml
+++ b/golangci.yml
@@ -42,11 +42,20 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - lll
-    - gofumpt
+    - deadcode
     - exhaustivestruct
-    - forcetypeassert
     - exhaustruct
+    - forcetypeassert
+    - gofumpt
+    - golint
+    - ifshort
+    - interfacer
+    - lll
+    - maligned
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - varcheck
   disable-all: false
   fast: false
 

--- a/golangci.yml
+++ b/golangci.yml
@@ -19,14 +19,10 @@ linters-settings:
   govet:
     check-shadowing: true
     use-installed-packages: false
-  golint:
-    min-confidence: 0.8
   gofmt:
     simplify: true
   gocyclo:
     min-complexity: 20
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 200
   goconst:

--- a/twingate/datasource_user.go
+++ b/twingate/datasource_user.go
@@ -44,9 +44,11 @@ func datasourceUserRead(ctx context.Context, resourceData *schema.ResourceData, 
 	return diags
 }
 
+const userDescription = "Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's [documentation](https://docs.twingate.com/docs/users)."
+
 func datasourceUser() *schema.Resource {
 	return &schema.Resource{
-		Description: "Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's [documentation](https://docs.twingate.com/docs/users).",
+		Description: userDescription,
 		ReadContext: datasourceUserRead,
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/twingate/datasource_user.go
+++ b/twingate/datasource_user.go
@@ -44,7 +44,7 @@ func datasourceUserRead(ctx context.Context, resourceData *schema.ResourceData, 
 	return diags
 }
 
-const userDescription = "Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's [documentation](https://docs.twingate.com/docs/users)."
+const userDescription = "Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see Twingate's [documentation](https://docs.twingate.com/docs/users)."
 
 func datasourceUser() *schema.Resource {
 	return &schema.Resource{

--- a/twingate/datasource_users.go
+++ b/twingate/datasource_users.go
@@ -47,7 +47,7 @@ func convertUsersToTerraform(users []*User) []interface{} {
 
 func datasourceUsers() *schema.Resource {
 	return &schema.Resource{
-		Description: "Users in Twingate can be given access to Twingate Resources and may either be added manually or automatically synchronized with a 3rd party identity provider. For more information, see see Twingate's [documentation](https://docs.twingate.com/docs/users).",
+		Description: userDescription,
 		ReadContext: datasourceUsersRead,
 		Schema: map[string]*schema.Schema{
 			"users": {


### PR DESCRIPTION
Resolves #198 

# Changes
Ignores deprecated linters:
```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'nosnakecase' is deprecated (since v1.48.1) due to: The repository of the linter has been deprecated by the owner.  Replaced by revive(var-naming).
WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
```

Removed unnecessary lint ignores in code and fixed typos