### PR TITLE
CUS-3 | Migrate token verification to v4 API

### DIFF
--- a/twingate/client.go
+++ b/twingate/client.go
@@ -146,7 +146,7 @@ func (s *serverURL) newGraphqlServerURL() string {
 }
 
 func (s *serverURL) newAPIServerURL() string {
-	return fmt.Sprintf("%s/api/v1", s.url)
+	return fmt.Sprintf("%s/api/v4", s.url)
 }
 
 type serverURL struct {

--- a/twingate/client_connector_tokens.go
+++ b/twingate/client_connector_tokens.go
@@ -22,6 +22,7 @@ func (client *Client) verifyConnectorTokens(ctx context.Context, refreshToken, a
 		map[string]string{
 			"refresh_token": refreshToken,
 		})
+
 	if err != nil {
 		return NewAPIError(err, "verify", connectorTokensResourceName)
 	}
@@ -29,7 +30,7 @@ func (client *Client) verifyConnectorTokens(ctx context.Context, refreshToken, a
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
-		fmt.Sprintf("%s/access_node/refresh", client.APIServerURL),
+		fmt.Sprintf("%s/connector/validate_tokens", client.APIServerURL),
 		bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return NewAPIError(err, "verify", connectorTokensResourceName)

--- a/twingate/client_connector_tokens_test.go
+++ b/twingate/client_connector_tokens_test.go
@@ -50,7 +50,7 @@ func TestClientConnectorTokensVerifyOK(t *testing.T) {
 	accessToken := "test1"
 	refreshToken := "test2"
 
-	httpmock.RegisterResponder("POST", client.APIServerURL+"/access_node/refresh",
+	httpmock.RegisterResponder("POST", client.APIServerURL+"/connector/validate_tokens",
 		func(req *http.Request) (*http.Response, error) {
 			header := req.Header.Get("Authorization")
 			assert.Contains(t, header, accessToken)
@@ -72,7 +72,7 @@ func TestClientConnectorTokensVerify401Error(t *testing.T) {
 	accessToken := "test1"
 	refreshToken := "test2"
 
-	apiURL := client.APIServerURL + "/access_node/refresh"
+	apiURL := client.APIServerURL + "/connector/validate_tokens"
 	httpmock.RegisterResponder("POST", apiURL,
 		func(req *http.Request) (*http.Response, error) {
 			header := req.Header.Get("Authorization")
@@ -92,7 +92,7 @@ func TestClientConnectorTokensVerifyRequestError(t *testing.T) {
 	refreshToken := "test2"
 
 	defer httpmock.DeactivateAndReset()
-	apiURL := client.APIServerURL + "/access_node/refresh"
+	apiURL := client.APIServerURL + "/connector/validate_tokens"
 	httpmock.RegisterResponder("POST", apiURL,
 		func(req *http.Request) (*http.Response, error) {
 			header := req.Header.Get("Authorization")


### PR DESCRIPTION
Resolves #199 

## Changes
- Calls `/api/v4/connector/validate_tokens` instead of `/api/v1/refresh` - call signature is the same 
