### PR TITLE
Fix acc tests

### DIFF
--- a/twingate/datasource_connector_test.go
+++ b/twingate/datasource_connector_test.go
@@ -22,7 +22,7 @@ func TestAccDatasourceTwingateConnector_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateConnector(networkName, connectorName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckOutput("my_connector", connectorName),
 					),
 				},

--- a/twingate/datasource_connectors_test.go
+++ b/twingate/datasource_connectors_test.go
@@ -23,7 +23,7 @@ func TestAccDatasourceTwingateConnectors_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateConnectors(networkName1, connectorName, networkName2, connectorName, getTestPrefix()),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testCheckOutputLength("my_connectors", 2),
 						testCheckOutputAttr("my_connectors", 0, "name", connectorName),
 					),
@@ -69,7 +69,7 @@ func TestAccDatasourceTwingateConnectors_emptyResult(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testTwingateConnectorsDoesNotExists(prefix),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testCheckOutputLength("my_connectors_dcs2", 0),
 					),
 				},

--- a/twingate/datasource_group_test.go
+++ b/twingate/datasource_group_test.go
@@ -21,7 +21,7 @@ func TestAccDatasourceTwingateGroup_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateGroup(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckOutput("my_group_dg1", groupName),
 						resource.TestCheckOutput("my_group_is_active_dg1", "true"),
 						resource.TestCheckOutput("my_group_type_dg1", "MANUAL"),

--- a/twingate/datasource_groups_test.go
+++ b/twingate/datasource_groups_test.go
@@ -26,7 +26,7 @@ func TestAccDatasourceTwingateGroups_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateGroups(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(theDatasource, groupsNumber, "2"),
 						resource.TestCheckResourceAttr(theDatasource, firstGroupName, groupName),
 					),
@@ -64,7 +64,7 @@ func TestAccDatasourceTwingateGroups_emptyResult(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testTwingateGroupsDoesNotExists(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.twingate_groups.out_dgs2", groupsNumber, "0"),
 					),
 				},
@@ -92,7 +92,7 @@ func TestAccDatasourceTwingateGroupsWithFilters_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateGroupsWithFilters(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(theDatasource, groupsNumber, "2"),
 						resource.TestCheckResourceAttr(theDatasource, firstGroupName, groupName),
 					),
@@ -189,7 +189,7 @@ func TestAccDatasourceTwingateGroups_withTwoDatasource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateGroupsWithDatasource(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.twingate_groups.two_dgs3", firstGroupName, groupName),
 						resource.TestCheckResourceAttr("data.twingate_groups.one_dgs3", groupsNumber, "1"),
 						resource.TestCheckResourceAttr("data.twingate_groups.two_dgs3", groupsNumber, "2"),

--- a/twingate/datasource_remote_network_test.go
+++ b/twingate/datasource_remote_network_test.go
@@ -22,7 +22,7 @@ func TestAccDatasourceTwingateRemoteNetwork_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateRemoteNetwork(networkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.twingate_remote_network.test_dn1_2", "name", networkName),
 					),
 				},
@@ -59,7 +59,7 @@ func TestAccDatasourceTwingateRemoteNetworkByName_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateRemoteNetworkByName(networkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.twingate_remote_network.test_dn2_2", "name", networkName),
 					),
 				},

--- a/twingate/datasource_resource_test.go
+++ b/twingate/datasource_resource_test.go
@@ -22,7 +22,7 @@ func TestAccDatasourceTwingateResource_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateResource(networkName, resourceName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.twingate_resource.out_dr1", "name", resourceName),
 					),
 				},

--- a/twingate/datasource_resources_test.go
+++ b/twingate/datasource_resources_test.go
@@ -27,7 +27,7 @@ func TestAccDatasourceTwingateResources_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateResources(networkName, resourceName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(theDatasource, resourcesNumber, "2"),
 						resource.TestCheckResourceAttr(theDatasource, firstResourceName, resourceName),
 					),
@@ -97,7 +97,7 @@ func TestAccDatasourceTwingateResources_emptyResult(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testTwingateResourcesDoesNotExists(resourceName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.twingate_resources.out_drs2", resourcesNumber, "0"),
 					),
 				},

--- a/twingate/datasource_user_test.go
+++ b/twingate/datasource_user_test.go
@@ -25,7 +25,7 @@ func TestAccDatasourceTwingateUser_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateUser(user.ID),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						resource.TestCheckOutput("my_user_email_du1", user.Email),
 					),
 				},

--- a/twingate/datasource_users_test.go
+++ b/twingate/datasource_users_test.go
@@ -16,7 +16,7 @@ func TestAccDatasourceTwingateUsers_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testDatasourceTwingateUsers(),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testCheckResourceAttrNotEqual("data.twingate_users.all", "users.#", "0"),
 					),
 				},

--- a/twingate/resource_connector_test.go
+++ b/twingate/resource_connector_test.go
@@ -31,7 +31,7 @@ func TestAccRemoteConnectorCreate(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createConnectorC1(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorExists(theResource, "twingate_remote_network.test_c1"),
 						resource.TestCheckResourceAttrSet(theResource, "name"),
 					),
@@ -66,7 +66,7 @@ func TestAccRemoteConnectorWithCustomName(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createConnectorC2(remoteNetworkName, connectorName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorExists(theResource, "twingate_remote_network.test_c2"),
 						resource.TestMatchResourceAttr(theResource, "name", regexp.MustCompile(connectorName)),
 					),
@@ -143,7 +143,7 @@ func TestAccRemoteConnectorImport(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createConnectorC3(remoteNetworkName, connectorName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorExists(theResource, "twingate_remote_network.test_c3"),
 						resource.TestMatchResourceAttr(theResource, "name", testRegexp),
 					),
@@ -183,7 +183,7 @@ func TestAccRemoteConnectorNotAllowedToChangeRemoteNetworkId(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createConnectorC4(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorExists(theResource, "twingate_remote_network.test_c4_1"),
 					),
 				},
@@ -230,7 +230,7 @@ func TestAccTwingateConnectorReCreateAfterDeletion(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createConnectorC5(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorExists(theResource, "twingate_remote_network.test_c5"),
 						deleteTwingateResource(theResource, connectorResourceName),
 					),
@@ -238,7 +238,7 @@ func TestAccTwingateConnectorReCreateAfterDeletion(t *testing.T) {
 				},
 				{
 					Config: createConnectorC5(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorExists(theResource, "twingate_remote_network.test_c5"),
 					),
 				},

--- a/twingate/resource_connector_tokens_test.go
+++ b/twingate/resource_connector_tokens_test.go
@@ -22,7 +22,7 @@ func TestAccRemoteConnectorWithTokens(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createConnectorTokensWithKeepers(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateConnectorTokensExists(connectorTokensResource),
 					),
 				},

--- a/twingate/resource_group_test.go
+++ b/twingate/resource_group_test.go
@@ -26,14 +26,14 @@ func TestAccTwingateGroupCreateUpdate(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createGroup001(groupNameBefore),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateGroupExists(theResource),
 						resource.TestCheckResourceAttr(theResource, "name", groupNameBefore),
 					),
 				},
 				{
 					Config: createGroup001(groupNameAfter),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateGroupExists(theResource),
 						resource.TestCheckResourceAttr(theResource, "name", groupNameAfter),
 					),
@@ -64,7 +64,7 @@ func TestAccTwingateGroupDeleteNonExisting(t *testing.T) {
 				{
 					Config:  createGroup002(groupNameBefore),
 					Destroy: true,
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateGroupDoesNotExists("twingate_group.test002"),
 					),
 				},
@@ -141,7 +141,7 @@ func TestAccTwingateGroupReCreateAfterDeletion(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createGroup003(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateGroupExists(theResource),
 						deleteTwingateResource(theResource, groupResourceName),
 					),
@@ -149,7 +149,7 @@ func TestAccTwingateGroupReCreateAfterDeletion(t *testing.T) {
 				},
 				{
 					Config: createGroup003(groupName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateGroupExists(theResource),
 					),
 				},

--- a/twingate/resource_remote_network_test.go
+++ b/twingate/resource_remote_network_test.go
@@ -24,14 +24,14 @@ func TestAccTwingateRemoteNetworkCreateUpdate(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createRemoteNetwork001(remoteNetworkNameBefore),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateRemoteNetworkExists(theResource),
 						resource.TestCheckResourceAttr(theResource, "name", remoteNetworkNameBefore),
 					),
 				},
 				{
 					Config: createRemoteNetwork001(remoteNetworkNameAfter),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateRemoteNetworkExists(theResource),
 						resource.TestCheckResourceAttr(theResource, "name", remoteNetworkNameAfter),
 					),
@@ -62,7 +62,7 @@ func TestAccTwingateRemoteNetworkDeleteNonExisting(t *testing.T) {
 				{
 					Config:  createRemoteNetwork002(remoteNetworkNameBefore),
 					Destroy: true,
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateRemoteNetworkDoesNotExists("twingate_remote_network.test002"),
 					),
 				},
@@ -141,7 +141,7 @@ func TestAccTwingateRemoteNetworkReCreateAfterDeletion(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: createRemoteNetwork003(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateRemoteNetworkExists(theResource),
 						deleteTwingateResource(theResource, remoteNetworkResourceName),
 					),
@@ -149,7 +149,7 @@ func TestAccTwingateRemoteNetworkReCreateAfterDeletion(t *testing.T) {
 				},
 				{
 					Config: createRemoteNetwork003(remoteNetworkName),
-					Check: resource.ComposeTestCheckFunc(
+					Check: ComposeTestCheckFunc(
 						testAccCheckTwingateRemoteNetworkExists(theResource),
 					),
 				},

--- a/twingate/resource_resource_test.go
+++ b/twingate/resource_resource_test.go
@@ -3,8 +3,10 @@ package twingate
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,6 +25,15 @@ const (
 	tcpPorts       = "protocols.0.tcp.0.ports.#"
 	udpPorts       = "protocols.0.udp.0.ports.#"
 )
+
+func wait() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Sleep between 500ms-1s
+		n := 500 + rand.Intn(500) // n will be between 0 and 10
+		time.Sleep(time.Duration(n) * time.Millisecond)
+		return nil
+	}
+}
 
 func TestAccTwingateResourceCreate(t *testing.T) {
 	remoteNetworkName := getRandomName()
@@ -585,6 +596,7 @@ func TestAccTwingateResourceSetActiveStateOnUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTwingateResourceExists(theResource),
 					deactivateTwingateResource(theResource),
+					wait(),
 					testAccCheckTwingateResourceActiveState(theResource, false),
 				),
 			},

--- a/twingate/resource_resource_test.go
+++ b/twingate/resource_resource_test.go
@@ -3,13 +3,14 @@ package twingate
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/twingate/go-graphql-client"
-	"regexp"
-	"testing"
 )
 
 const (

--- a/twingate/resource_resource_test.go
+++ b/twingate/resource_resource_test.go
@@ -584,7 +584,7 @@ func TestAccTwingateResourceSetActiveStateOnUpdate(t *testing.T) {
 				Check: ComposeTestCheckFunc(
 					testAccCheckTwingateResourceExists(theResource),
 					deactivateTwingateResource(theResource),
-					wait(),
+					WaitTestFunc(),
 					testAccCheckTwingateResourceActiveState(theResource, false),
 				),
 			},

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -18,13 +18,13 @@ func WaitTestFunc() resource.TestCheckFunc {
 	}
 }
 
-func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc {
+func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc { // nolint:varnamelen
 	return func(s *terraform.State) error {
 		_ = WaitTestFunc()(s)
 
 		for i, f := range fs {
 			if err := f(s); err != nil {
-				return fmt.Errorf("check %d/%d error: %s", i+1, len(fs), err)
+				return fmt.Errorf("check %d/%d error: %w", i+1, len(fs), err)
 			}
 		}
 

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -11,7 +11,7 @@ import (
 const WaitDuration = 500 * time.Millisecond
 
 func WaitTestFunc() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(state *terraform.State) error {
 		// Sleep 500 ms
 		time.Sleep(WaitDuration)
 
@@ -20,13 +20,13 @@ func WaitTestFunc() resource.TestCheckFunc {
 }
 
 func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc { //nolint:varnamelen
-	return func(s *terraform.State) error {
-		if err := WaitTestFunc()(s); err != nil {
+	return func(state *terraform.State) error {
+		if err := WaitTestFunc()(state); err != nil {
 			return fmt.Errorf("WaitTestFunc error: %w", err)
 		}
 
 		for i, f := range fs {
-			if err := f(s); err != nil {
+			if err := f(state); err != nil {
 				return fmt.Errorf("check %d/%d error: %w", i+1, len(fs), err)
 			}
 		}

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -1,0 +1,32 @@
+package twingate
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"math/rand"
+	"time"
+)
+
+func wait() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Sleep between 500ms-1s
+		n := 500 + rand.Intn(500) // n will be between 0 and 10
+		time.Sleep(time.Duration(n) * time.Millisecond)
+		return nil
+	}
+}
+
+func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_ = wait()(s)
+
+		for i, f := range fs {
+			if err := f(s); err != nil {
+				return fmt.Errorf("Check %d/%d error: %s", i+1, len(fs), err)
+			}
+		}
+
+		return nil
+	}
+}

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -7,12 +7,13 @@ import (
 	"time"
 )
 
-const WaitDuration = time.Duration(500) * time.Millisecond
+const WaitDuration = 500 * time.Millisecond
 
 func WaitTestFunc() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Sleep 500 ms
 		time.Sleep(WaitDuration)
+
 		return nil
 	}
 }
@@ -23,7 +24,7 @@ func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc {
 
 		for i, f := range fs {
 			if err := f(s); err != nil {
-				return fmt.Errorf("Check %d/%d error: %s", i+1, len(fs), err)
+				return fmt.Errorf("check %d/%d error: %s", i+1, len(fs), err)
 			}
 		}
 

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -7,10 +7,12 @@ import (
 	"time"
 )
 
+const WaitDuration = time.Duration(500) * time.Millisecond
+
 func WaitTestFunc() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Sleep 500 ms
-		time.Sleep(time.Duration(500) * time.Millisecond)
+		time.Sleep(WaitDuration)
 		return nil
 	}
 }

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"math/rand"
 	"time"
 )
 
 func WaitTestFunc() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Sleep between 500ms-1s
-		n := 500 + rand.Intn(500) // n will be between 0 and 10
-		time.Sleep(time.Duration(n) * time.Millisecond)
+		// Sleep 500 ms
+		time.Sleep(time.Duration(500) * time.Millisecond)
 		return nil
 	}
 }

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func wait() resource.TestCheckFunc {
+func WaitTestFunc() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Sleep between 500ms-1s
 		n := 500 + rand.Intn(500) // n will be between 0 and 10
@@ -19,7 +19,7 @@ func wait() resource.TestCheckFunc {
 
 func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_ = wait()(s)
+		_ = WaitTestFunc()(s)
 
 		for i, f := range fs {
 			if err := f(s); err != nil {

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -19,9 +19,11 @@ func WaitTestFunc() resource.TestCheckFunc {
 	}
 }
 
-func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc { // nolint:varnamelen
+func ComposeTestCheckFunc(fs ...resource.TestCheckFunc) resource.TestCheckFunc { //nolint:varnamelen
 	return func(s *terraform.State) error {
-		_ = WaitTestFunc()(s)
+		if err := WaitTestFunc()(s); err != nil {
+			return fmt.Errorf("WaitTestFunc error: %w", err)
+		}
 
 		for i, f := range fs {
 			if err := f(s); err != nil {

--- a/twingate/test_utils.go
+++ b/twingate/test_utils.go
@@ -2,9 +2,10 @@ package twingate
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"time"
 )
 
 const WaitDuration = 500 * time.Millisecond


### PR DESCRIPTION
Fixes acceptance test random failures

## Changes
Add a delay between the test's `config` phase and `check` phase. As check usually query replica DBs there's a chance of a small replication delay
