### PR TITLE
Fix remote-network update

### DIFF
--- a/twingate/internal/client/remote-network.go
+++ b/twingate/internal/client/remote-network.go
@@ -126,7 +126,7 @@ func (client *Client) ReadRemoteNetworkByName(ctx context.Context, remoteNetwork
 func (client *Client) UpdateRemoteNetwork(ctx context.Context, req *model.RemoteNetwork) (*model.RemoteNetwork, error) {
 	variables := newVars(
 		gqlID(req.ID),
-		gqlVar(req.Name, "name"),
+		gqlNullable(req.Name, "name"),
 		gqlVar(RemoteNetworkLocation(req.Location), "location"),
 	)
 

--- a/twingate/internal/provider/resource/remote-network.go
+++ b/twingate/internal/provider/resource/remote-network.go
@@ -60,10 +60,15 @@ func remoteNetworkCreate(ctx context.Context, resourceData *schema.ResourceData,
 func remoteNetworkUpdate(ctx context.Context, resourceData *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] Updating remote network id %s", resourceData.Id())
 
+	var name string
+	if resourceData.HasChange("name") {
+		name = resourceData.Get("name").(string)
+	}
+
 	c := meta.(*client.Client)
 	remoteNetwork, err := c.UpdateRemoteNetwork(ctx, &model.RemoteNetwork{
 		ID:       resourceData.Id(),
-		Name:     resourceData.Get("name").(string),
+		Name:     name,
 		Location: resourceData.Get("location").(string),
 	})
 

--- a/twingate/internal/test/acctests/resource/remote-network_test.go
+++ b/twingate/internal/test/acctests/resource/remote-network_test.go
@@ -140,3 +140,35 @@ func TestAccTwingateRemoteNetworkReCreateAfterDeletion(t *testing.T) {
 		})
 	})
 }
+
+func TestAccTwingateRemoteNetworkUpdateWithTheSameName(t *testing.T) {
+	t.Run("Test Twingate Resource : Acc Remote Network Update With The Same Name", func(t *testing.T) {
+		const terraformResourceName = "test004"
+		theResource := acctests.TerraformRemoteNetwork(terraformResourceName)
+		name := test.RandomName()
+
+		sdk.Test(t, sdk.TestCase{
+			ProviderFactories: acctests.ProviderFactories,
+			PreCheck:          func() { acctests.PreCheck(t) },
+			CheckDestroy:      acctests.CheckTwingateRemoteNetworkDestroy,
+			Steps: []sdk.TestStep{
+				{
+					Config: terraformResourceRemoteNetwork(terraformResourceName, name),
+					Check: acctests.ComposeTestCheckFunc(
+						acctests.CheckTwingateResourceExists(theResource),
+						sdk.TestCheckResourceAttr(theResource, nameAttr, name),
+						sdk.TestCheckResourceAttr(theResource, locationAttr, model.LocationOther),
+					),
+				},
+				{
+					Config: createRemoteNetworkWithLocation(terraformResourceName, name, model.LocationAWS),
+					Check: acctests.ComposeTestCheckFunc(
+						acctests.CheckTwingateResourceExists(theResource),
+						sdk.TestCheckResourceAttr(theResource, nameAttr, name),
+						sdk.TestCheckResourceAttr(theResource, locationAttr, model.LocationAWS),
+					),
+				},
+			},
+		})
+	})
+}


### PR DESCRIPTION
Resolves https://github.com/Twingate/terraform-provider-twingate/issues/239

## Changes
- fix update remote-network name

```

# module.remote_network["aws_euw2"].twingate_remote_network.this will be updated in-place
  ~ resource "twingate_remote_network" "this" {
        id       = "UmVtb3RlTmV0d29yazoxODgzMQ=="
      ~ location = "AWS" -> "OTHER"
        name     = "aws-euw2"
    }
    

```

in this case user would need to add new line to the terraform resource to keep the same value for location

`location = "AWS" `

    
    
    