### PR TITLE
Release as draft first

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,6 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-# If you want to manually examine the release before its live, uncomment this line:
-# draft: true
+  draft: true
 changelog:
   skip: true


### PR DESCRIPTION
Resolves #244 

## Changes
- Make new releases as drafts so we publish them after Changelog is written
