### PR TITLE
Fix: prevent provider from hanging on invalid server URL

### DIFF
--- a/twingate/internal/client/client.go
+++ b/twingate/internal/client/client.go
@@ -36,7 +36,8 @@ var (
 	// A regular expression to match the error returned by net/http when the
 	// TLS certificate name is not match with input. This error isn't typed
 	// specifically so we resort to matching on the error string.
-	certNameNotMatchErrorRe = regexp.MustCompile(`certificate name does not match input`)
+	certNameNotMatchMacErrorRe   = regexp.MustCompile(`certificate name does not match input`)
+	certNameNotMatchLinuxErrorRe = regexp.MustCompile(`certificate is valid for`)
 )
 
 type Client struct {
@@ -115,7 +116,8 @@ func customRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 	// do not retry if there is an issue with TLS certificate
 	if err != nil {
 		if v, ok := err.(*url.Error); ok { //nolint:errorlint
-			if certNameNotMatchErrorRe.MatchString(v.Error()) {
+			if certNameNotMatchMacErrorRe.MatchString(v.Error()) ||
+				certNameNotMatchLinuxErrorRe.MatchString(v.Error()) {
 				return false, v
 			}
 		}

--- a/twingate/internal/client/client.go
+++ b/twingate/internal/client/client.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -28,7 +30,14 @@ const (
 	headerAgent  = "User-Agent"
 )
 
-var ErrAPITokenNoSet = errors.New("api_token not set")
+var (
+	ErrAPITokenNoSet = errors.New("api_token not set")
+
+	// A regular expression to match the error returned by net/http when the
+	// TLS certificate name is not match with input. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	certNameNotMatchErrorRe = regexp.MustCompile(`certificate name does not match input`)
+)
 
 type Client struct {
 	GraphqlClient    *graphql.Client
@@ -101,6 +110,15 @@ func customRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 	// do not retry if API token not set
 	if errors.Is(err, ErrAPITokenNoSet) {
 		return false, err
+	}
+
+	// do not retry if there is an issue with TLS certificate
+	if err != nil {
+		if v, ok := err.(*url.Error); ok { //nolint:errorlint
+			if certNameNotMatchErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+		}
 	}
 
 	return retryablehttp.DefaultRetryPolicy(ctx, resp, err) //nolint

--- a/twingate/internal/client/client_test.go
+++ b/twingate/internal/client/client_test.go
@@ -104,5 +104,6 @@ func TestClientInvalidServerAddress(t *testing.T) {
 
 	_, err := client.post(context.TODO(), "/hello", "hello", nil)
 
-	assert.ErrorContains(t, err, `certificate name does not match input`)
+	assert.ErrorContains(t, err, `x509`)
+	assert.ErrorContains(t, err, `certificate`)
 }

--- a/twingate/internal/client/client_test.go
+++ b/twingate/internal/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 )
@@ -88,4 +89,20 @@ func TestClientAPITokenNotSet(t *testing.T) {
 	_, err = client.post(context.TODO(), "/hello", "hello", nil)
 
 	assert.ErrorContains(t, err, "lookup test.twindev.com: no such host")
+}
+
+func TestClientInvalidServerAddress(t *testing.T) {
+	client := NewClient(
+		"beamreach.twingate.com", "XXXXX", "beamreach",
+		time.Duration(10)*time.Second, 3, "test",
+	)
+
+	internal := client.HTTPClient.Transport.(*retryablehttp.RoundTripper)
+	internal.Client.RequestLogHook = func(logger retryablehttp.Logger, req *http.Request, retryNumber int) {
+		assert.Less(t, retryNumber, 3)
+	}
+
+	_, err := client.post(context.TODO(), "/hello", "hello", nil)
+
+	assert.ErrorContains(t, err, `certificate name does not match input`)
 }


### PR DESCRIPTION
Resolves https://github.com/Twingate/terraform-provider-twingate/issues/282

## Changes
- added check for TLS certificate error, to break re-try loop in this case
