### PR TITLE
Fix acc tests terraform versions (Remove ACC tests on EOL TF versions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.0.*'
-          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
           - 'latest'
     steps:
 


### PR DESCRIPTION
Resolves #300 

## Changes
Based on https://endoflife.date/terraform versions 1.0 and 1.1 are now dead so we should be testing on 1.2, 1.3 and latest
<img width="839" alt="Screenshot 2023-03-06 at 1 42 49 PM" src="https://user-images.githubusercontent.com/205185/223239128-223684ef-e70d-4bb9-8ff7-58c943219e5f.png">
