### PR TITLE
CI Fixes - Goreleaser, Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,14 @@ jobs:
 
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
       with:
         path: ${{ env.GOCACHE }}
         key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
@@ -95,12 +97,14 @@ jobs:
 
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
       with:
         path: ${{ env.GOCACHE }}
         key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,6 @@ jobs:
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ${{ env.GOCACHE }}
-        key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}      
-
     - name: Get dependencies
       run: |
         go mod download
@@ -97,20 +83,6 @@ jobs:
 
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ${{ env.GOCACHE }}
-        key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}      
 
     - name: Get dependencies
       run: |
@@ -174,19 +146,7 @@ jobs:
 
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ${{ env.GOCACHE }}
-        key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}      
-        
+
     - name: Get dependencies
       run: |
         go mod download
@@ -227,18 +187,6 @@ jobs:
 
       - name: go env
         run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-      - uses: actions/cache@v3
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,8 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version-file: 'go.mod'
+          cache: true
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -26,12 +26,14 @@ jobs:
 
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
       with:
         path: ${{ env.GOCACHE }}
         key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
@@ -78,12 +80,14 @@ jobs:
 
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
       with:
         path: ${{ env.GOCACHE }}
         key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+
     - uses: actions/cache@v3
       continue-on-error: true
       timeout-minutes: 2
@@ -136,12 +140,14 @@ jobs:
 
       - name: go env
         run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2
         with:
           path: ${{ env.GOCACHE }}
           key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+          
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -27,20 +27,6 @@ jobs:
     - name: go env
       run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ${{ env.GOCACHE }}
-        key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-
-    - uses: actions/cache@v3
-      continue-on-error: true
-      timeout-minutes: 2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-
     - name: Get dependencies
       run: |
         go mod download
@@ -140,20 +126,6 @@ jobs:
 
       - name: go env
         run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-
-      - uses: actions/cache@v3
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -45,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.0.*'
-          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
           - 'latest'
     steps:
     - name: Check out code into the Go module directory

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           path: ${{ env.GOCACHE }}
           key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-          
+
       - uses: actions/cache@v3
         continue-on-error: true
         timeout-minutes: 2


### PR DESCRIPTION
Resolves #297

## Changes
- Fix Go caching - `setup-go` does caching and `actions/cache@v3` wasn't really doing anything but taking a lot of time
- Fix goreleaser (proof: https://github.com/Twingate/terraform-provider-twingate/actions/runs/4349434349)