### PR TITLE
Fix smoketests to not test on deprecated SDK versions

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -57,8 +57,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.0.*'
-          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
           - 'latest'
     steps:
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Resolves #300 

