### PR TITLE
Fix: missing query cursors and page limit

### DIFF
--- a/twingate/internal/client/client_test.go
+++ b/twingate/internal/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Twingate/terraform-provider-twingate/twingate"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -72,9 +73,9 @@ func TestClientFailedReadBody(t *testing.T) {
 }
 
 func TestClientAPITokenNotSet(t *testing.T) {
-	apiToken := os.Getenv(EnvAPIToken)
-	os.Setenv(EnvAPIToken, "")
-	defer os.Setenv(EnvAPIToken, apiToken)
+	apiToken := os.Getenv(twingate.EnvAPIToken)
+	os.Setenv(twingate.EnvAPIToken, "")
+	defer os.Setenv(twingate.EnvAPIToken, apiToken)
 
 	client := NewClient(
 		"twindev.com", "", "test",
@@ -85,7 +86,7 @@ func TestClientAPITokenNotSet(t *testing.T) {
 
 	assert.ErrorContains(t, err, ErrAPITokenNoSet.Error())
 
-	os.Setenv(EnvAPIToken, "xxx")
+	os.Setenv(twingate.EnvAPIToken, "xxx")
 	_, err = client.post(context.TODO(), "/hello", "hello", nil)
 
 	assert.ErrorContains(t, err, "lookup test.twindev.com")

--- a/twingate/internal/client/client_test.go
+++ b/twingate/internal/client/client_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Twingate/terraform-provider-twingate/twingate"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -73,9 +72,9 @@ func TestClientFailedReadBody(t *testing.T) {
 }
 
 func TestClientAPITokenNotSet(t *testing.T) {
-	apiToken := os.Getenv(twingate.EnvAPIToken)
-	os.Setenv(twingate.EnvAPIToken, "")
-	defer os.Setenv(twingate.EnvAPIToken, apiToken)
+	apiToken := os.Getenv(EnvAPIToken)
+	os.Setenv(EnvAPIToken, "")
+	defer os.Setenv(EnvAPIToken, apiToken)
 
 	client := NewClient(
 		"twindev.com", "", "test",
@@ -86,7 +85,7 @@ func TestClientAPITokenNotSet(t *testing.T) {
 
 	assert.ErrorContains(t, err, ErrAPITokenNoSet.Error())
 
-	os.Setenv(twingate.EnvAPIToken, "xxx")
+	os.Setenv(EnvAPIToken, "xxx")
 	_, err = client.post(context.TODO(), "/hello", "hello", nil)
 
 	assert.ErrorContains(t, err, "lookup test.twindev.com")

--- a/twingate/internal/client/connector.go
+++ b/twingate/internal/client/connector.go
@@ -77,12 +77,15 @@ func (client *Client) ReadConnector(ctx context.Context, connectorID string) (*m
 }
 
 func (client *Client) ReadConnectors(ctx context.Context) ([]*model.Connector, error) {
-	op := resourceConnector.read()
+	opr := resourceConnector.read()
 
-	variables := newVars(gqlNullable("", query.CursorConnectors))
+	variables := newVars(
+		gqlNullable("", query.CursorConnectors),
+		gqlVar(client.pageLimit, query.PageLimitConnectors),
+	)
 
 	response := query.ReadConnectors{}
-	if err := client.query(ctx, &response, variables, op.withCustomName("readConnectors"), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readConnectors"), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 
@@ -94,12 +97,12 @@ func (client *Client) ReadConnectors(ctx context.Context) ([]*model.Connector, e
 }
 
 func (client *Client) readConnectorsAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.ConnectorEdge], error) {
-	op := resourceConnector.read()
+	opr := resourceConnector.read()
 
 	variables[query.CursorConnectors] = cursor
 
 	response := query.ReadConnectors{}
-	if err := client.query(ctx, &response, variables, op.withCustomName("readConnectors"), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readConnectors"), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 

--- a/twingate/internal/client/connector.go
+++ b/twingate/internal/client/connector.go
@@ -80,8 +80,8 @@ func (client *Client) ReadConnectors(ctx context.Context) ([]*model.Connector, e
 	opr := resourceConnector.read()
 
 	variables := newVars(
-		gqlNullable("", query.CursorConnectors),
-		gqlVar(client.pageLimit, query.PageLimitConnectors),
+		cursor(query.CursorConnectors),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadConnectors{}

--- a/twingate/internal/client/group.go
+++ b/twingate/internal/client/group.go
@@ -19,8 +19,8 @@ func (client *Client) CreateGroup(ctx context.Context, input *model.Group) (*mod
 		gqlVar(input.Name, "name"),
 		gqlIDs(input.Users, "userIds"),
 		gqlNullableID(input.SecurityPolicyID, "securityPolicyId"),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.CreateGroup{}
@@ -44,8 +44,8 @@ func (client *Client) ReadGroup(ctx context.Context, groupID string) (*model.Gro
 
 	variables := newVars(
 		gqlID(groupID),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadGroup{}
@@ -65,10 +65,9 @@ func (client *Client) ReadGroups(ctx context.Context, filter *model.GroupsFilter
 
 	variables := newVars(
 		gqlNullable(query.NewGroupFilterInput(filter), "filter"),
-		gqlNullable("", query.CursorGroups),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitGroups),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
+		cursor(query.CursorGroups),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadGroups{}
@@ -113,8 +112,8 @@ func (client *Client) UpdateGroup(ctx context.Context, input *model.Group) (*mod
 		gqlVar(input.Name, "name"),
 		gqlIDs(input.Users, "addedUserIds"),
 		gqlNullableID(input.SecurityPolicyID, "securityPolicyId"),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.UpdateGroup{}
@@ -122,7 +121,8 @@ func (client *Client) UpdateGroup(ctx context.Context, input *model.Group) (*mod
 		return nil, err
 	}
 
-	if err := response.Entity.Users.FetchPages(ctx, client.readGroupUsersAfter, newVars(gqlID(input.ID))); err != nil {
+	if err := response.Entity.Users.FetchPages(ctx,
+		client.readGroupUsersAfter, newVars(pageLimit(client.pageLimit), gqlID(input.ID))); err != nil {
 		return nil, err //nolint
 	}
 
@@ -158,8 +158,8 @@ func (client *Client) DeleteGroupUsers(ctx context.Context, groupID string, user
 	variables := newVars(
 		gqlID(groupID),
 		gqlIDs(userIDs, "removedUserIds"),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.UpdateGroupRemoveUsers{}
@@ -171,7 +171,6 @@ func (client *Client) readGroupUsersAfter(ctx context.Context, variables map[str
 	opr := resourceGroup.read()
 
 	variables[query.CursorUsers] = cursor
-	variables[query.PageLimitUsers] = client.pageLimit
 	resourceID := fmt.Sprintf("%v", variables["id"])
 
 	response := query.ReadGroup{}

--- a/twingate/internal/client/group.go
+++ b/twingate/internal/client/group.go
@@ -20,6 +20,7 @@ func (client *Client) CreateGroup(ctx context.Context, input *model.Group) (*mod
 		gqlIDs(input.Users, "userIds"),
 		gqlNullableID(input.SecurityPolicyID, "securityPolicyId"),
 		gqlNullable("", query.CursorUsers),
+		gqlVar(client.pageLimit, query.PageLimitUsers),
 	)
 
 	response := query.CreateGroup{}
@@ -44,6 +45,7 @@ func (client *Client) ReadGroup(ctx context.Context, groupID string) (*model.Gro
 	variables := newVars(
 		gqlID(groupID),
 		gqlNullable("", query.CursorUsers),
+		gqlVar(client.pageLimit, query.PageLimitUsers),
 	)
 
 	response := query.ReadGroup{}
@@ -65,6 +67,8 @@ func (client *Client) ReadGroups(ctx context.Context, filter *model.GroupsFilter
 		gqlNullable(query.NewGroupFilterInput(filter), "filter"),
 		gqlNullable("", query.CursorGroups),
 		gqlNullable("", query.CursorUsers),
+		gqlVar(client.pageLimit, query.PageLimitGroups),
+		gqlVar(client.pageLimit, query.PageLimitUsers),
 	)
 
 	response := query.ReadGroups{}
@@ -81,12 +85,12 @@ func (client *Client) ReadGroups(ctx context.Context, filter *model.GroupsFilter
 }
 
 func (client *Client) readGroupsAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.GroupEdge], error) {
-	op := resourceGroup.read()
+	opr := resourceGroup.read()
 
 	variables[query.CursorGroups] = cursor
 
 	response := query.ReadGroups{}
-	if err := client.query(ctx, &response, variables, op.withCustomName("readGroups"), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readGroups"), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 
@@ -110,6 +114,7 @@ func (client *Client) UpdateGroup(ctx context.Context, input *model.Group) (*mod
 		gqlIDs(input.Users, "addedUserIds"),
 		gqlNullableID(input.SecurityPolicyID, "securityPolicyId"),
 		gqlNullable("", query.CursorUsers),
+		gqlVar(client.pageLimit, query.PageLimitUsers),
 	)
 
 	response := query.UpdateGroup{}
@@ -154,6 +159,7 @@ func (client *Client) DeleteGroupUsers(ctx context.Context, groupID string, user
 		gqlID(groupID),
 		gqlIDs(userIDs, "removedUserIds"),
 		gqlNullable("", query.CursorUsers),
+		gqlVar(client.pageLimit, query.PageLimitUsers),
 	)
 
 	response := query.UpdateGroupRemoveUsers{}
@@ -165,6 +171,7 @@ func (client *Client) readGroupUsersAfter(ctx context.Context, variables map[str
 	opr := resourceGroup.read()
 
 	variables[query.CursorUsers] = cursor
+	variables[query.PageLimitUsers] = client.pageLimit
 	resourceID := fmt.Sprintf("%v", variables["id"])
 
 	response := query.ReadGroup{}

--- a/twingate/internal/client/query/connectors-read.go
+++ b/twingate/internal/client/query/connectors-read.go
@@ -5,13 +5,10 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const (
-	CursorConnectors    = "connectorsEndCursor"
-	PageLimitConnectors = "connectorsPageLimit"
-)
+const CursorConnectors = "connectorsEndCursor"
 
 type ReadConnectors struct {
-	Connectors `graphql:"connectors(after: $connectorsEndCursor, first: $connectorsPageLimit)"`
+	Connectors `graphql:"connectors(after: $connectorsEndCursor, first: $pageLimit)"`
 }
 
 type Connectors struct {

--- a/twingate/internal/client/query/connectors-read.go
+++ b/twingate/internal/client/query/connectors-read.go
@@ -5,10 +5,13 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorConnectors = "connectorsEndCursor"
+const (
+	CursorConnectors    = "connectorsEndCursor"
+	PageLimitConnectors = "connectorsPageLimit"
+)
 
 type ReadConnectors struct {
-	Connectors `graphql:"connectors(after: $connectorsEndCursor)"`
+	Connectors `graphql:"connectors(after: $connectorsEndCursor, first: $connectorsPageLimit)"`
 }
 
 type Connectors struct {

--- a/twingate/internal/client/query/group-read.go
+++ b/twingate/internal/client/query/group-read.go
@@ -13,7 +13,7 @@ type gqlGroup struct {
 	IDName
 	IsActive       bool
 	Type           string
-	Users          Users `graphql:"users(after: $usersEndCursor, first: $usersPageLimit)"`
+	Users          Users `graphql:"users(after: $usersEndCursor, first: $pageLimit)"`
 	SecurityPolicy gqlSecurityPolicy
 }
 

--- a/twingate/internal/client/query/group-read.go
+++ b/twingate/internal/client/query/group-read.go
@@ -13,7 +13,7 @@ type gqlGroup struct {
 	IDName
 	IsActive       bool
 	Type           string
-	Users          Users `graphql:"users(after: $usersEndCursor)"`
+	Users          Users `graphql:"users(after: $usersEndCursor, first: $usersPageLimit)"`
 	SecurityPolicy gqlSecurityPolicy
 }
 

--- a/twingate/internal/client/query/groups-read.go
+++ b/twingate/internal/client/query/groups-read.go
@@ -5,10 +5,13 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorGroups = "groupsEndCursor"
+const (
+	CursorGroups    = "groupsEndCursor"
+	PageLimitGroups = "groupsPageLimit"
+)
 
 type ReadGroups struct {
-	Groups `graphql:"groups(filter: $filter, after: $groupsEndCursor)"`
+	Groups `graphql:"groups(filter: $filter, after: $groupsEndCursor, first: $groupsPageLimit)"`
 }
 
 func (q ReadGroups) IsEmpty() bool {

--- a/twingate/internal/client/query/groups-read.go
+++ b/twingate/internal/client/query/groups-read.go
@@ -5,13 +5,10 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const (
-	CursorGroups    = "groupsEndCursor"
-	PageLimitGroups = "groupsPageLimit"
-)
+const CursorGroups = "groupsEndCursor"
 
 type ReadGroups struct {
-	Groups `graphql:"groups(filter: $filter, after: $groupsEndCursor, first: $groupsPageLimit)"`
+	Groups `graphql:"groups(filter: $filter, after: $groupsEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadGroups) IsEmpty() bool {

--- a/twingate/internal/client/query/pagination.go
+++ b/twingate/internal/client/query/pagination.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+const PageLimit = "pageLimit"
+
 type PageInfo struct {
 	EndCursor   string
 	HasNextPage bool

--- a/twingate/internal/client/query/remote-networks-read.go
+++ b/twingate/internal/client/query/remote-networks-read.go
@@ -5,10 +5,13 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorRemoteNetworks = "remoteNetworksEndCursor"
+const (
+	CursorRemoteNetworks    = "remoteNetworksEndCursor"
+	PageLimitRemoteNetworks = "remoteNetworksPageLimit"
+)
 
 type ReadRemoteNetworks struct {
-	RemoteNetworks `graphql:"remoteNetworks(after: $remoteNetworksEndCursor)"`
+	RemoteNetworks `graphql:"remoteNetworks(after: $remoteNetworksEndCursor, first: $remoteNetworksPageLimit)"`
 }
 
 func (q ReadRemoteNetworks) IsEmpty() bool {

--- a/twingate/internal/client/query/remote-networks-read.go
+++ b/twingate/internal/client/query/remote-networks-read.go
@@ -5,13 +5,10 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const (
-	CursorRemoteNetworks    = "remoteNetworksEndCursor"
-	PageLimitRemoteNetworks = "remoteNetworksPageLimit"
-)
+const CursorRemoteNetworks = "remoteNetworksEndCursor"
 
 type ReadRemoteNetworks struct {
-	RemoteNetworks `graphql:"remoteNetworks(after: $remoteNetworksEndCursor, first: $remoteNetworksPageLimit)"`
+	RemoteNetworks `graphql:"remoteNetworks(after: $remoteNetworksEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadRemoteNetworks) IsEmpty() bool {

--- a/twingate/internal/client/query/resource-groups-read.go
+++ b/twingate/internal/client/query/resource-groups-read.go
@@ -12,5 +12,5 @@ func (q ReadResourceGroups) IsEmpty() bool {
 
 type gqlResourceGroups struct {
 	ID     graphql.ID
-	Groups Groups `graphql:"groups(after: $groupsEndCursor, first: $groupsPageLimit)"`
+	Groups Groups `graphql:"groups(after: $groupsEndCursor, first: $pageLimit)"`
 }

--- a/twingate/internal/client/query/resource-groups-read.go
+++ b/twingate/internal/client/query/resource-groups-read.go
@@ -12,5 +12,5 @@ func (q ReadResourceGroups) IsEmpty() bool {
 
 type gqlResourceGroups struct {
 	ID     graphql.ID
-	Groups Groups `graphql:"groups(after: $groupsEndCursor)"`
+	Groups Groups `graphql:"groups(after: $groupsEndCursor, first: $groupsPageLimit)"`
 }

--- a/twingate/internal/client/query/resource-read.go
+++ b/twingate/internal/client/query/resource-read.go
@@ -16,7 +16,7 @@ func (q ReadResource) IsEmpty() bool {
 
 type gqlResource struct {
 	ResourceNode
-	Groups Groups
+	Groups Groups `graphql:"groups(after: $groupsEndCursor, first: $groupsPageLimit)"`
 }
 
 type ResourceNode struct {

--- a/twingate/internal/client/query/resource-read.go
+++ b/twingate/internal/client/query/resource-read.go
@@ -16,7 +16,7 @@ func (q ReadResource) IsEmpty() bool {
 
 type gqlResource struct {
 	ResourceNode
-	Groups Groups `graphql:"groups(after: $groupsEndCursor, first: $groupsPageLimit)"`
+	Groups Groups `graphql:"groups(after: $groupsEndCursor, first: $pageLimit)"`
 }
 
 type ResourceNode struct {

--- a/twingate/internal/client/query/resources-by-name-read.go
+++ b/twingate/internal/client/query/resources-by-name-read.go
@@ -1,7 +1,7 @@
 package query
 
 type ReadResourcesByName struct {
-	Resources `graphql:"resources(filter: {name: {eq: $name}}, after: $resourcesEndCursor, first: $resourcesPageLimit)"`
+	Resources `graphql:"resources(filter: {name: {eq: $name}}, after: $resourcesEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadResourcesByName) IsEmpty() bool {

--- a/twingate/internal/client/query/resources-by-name-read.go
+++ b/twingate/internal/client/query/resources-by-name-read.go
@@ -1,7 +1,7 @@
 package query
 
 type ReadResourcesByName struct {
-	Resources `graphql:"resources(filter: {name: {eq: $name}}, after: $resourcesEndCursor)"`
+	Resources `graphql:"resources(filter: {name: {eq: $name}}, after: $resourcesEndCursor, first: $resourcesPageLimit)"`
 }
 
 func (q ReadResourcesByName) IsEmpty() bool {

--- a/twingate/internal/client/query/resources-read.go
+++ b/twingate/internal/client/query/resources-read.go
@@ -5,10 +5,13 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorResources = "resourcesEndCursor"
+const (
+	CursorResources    = "resourcesEndCursor"
+	PageLimitResources = "resourcesPageLimit"
+)
 
 type ReadResources struct {
-	Resources `graphql:"resources(after: $resourcesEndCursor)"`
+	Resources `graphql:"resources(after: $resourcesEndCursor, first: $resourcesPageLimit)"`
 }
 
 func (r ReadResources) IsEmpty() bool {

--- a/twingate/internal/client/query/resources-read.go
+++ b/twingate/internal/client/query/resources-read.go
@@ -5,13 +5,10 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const (
-	CursorResources    = "resourcesEndCursor"
-	PageLimitResources = "resourcesPageLimit"
-)
+const CursorResources = "resourcesEndCursor"
 
 type ReadResources struct {
-	Resources `graphql:"resources(after: $resourcesEndCursor, first: $resourcesPageLimit)"`
+	Resources `graphql:"resources(after: $resourcesEndCursor, first: $pageLimit)"`
 }
 
 func (r ReadResources) IsEmpty() bool {

--- a/twingate/internal/client/query/security-policies-read.go
+++ b/twingate/internal/client/query/security-policies-read.go
@@ -5,13 +5,10 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const (
-	CursorPolicies    = "policiesEndCursor"
-	PageLimitPolicies = "policiesPageLimit"
-)
+const CursorPolicies = "policiesEndCursor"
 
 type ReadSecurityPolicies struct {
-	SecurityPolicies `graphql:"securityPolicies(after: $policiesEndCursor, first: $policiesPageLimit)"`
+	SecurityPolicies `graphql:"securityPolicies(after: $policiesEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadSecurityPolicies) IsEmpty() bool {

--- a/twingate/internal/client/query/security-policies-read.go
+++ b/twingate/internal/client/query/security-policies-read.go
@@ -5,10 +5,13 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorPolicies = "policiesEndCursor"
+const (
+	CursorPolicies    = "policiesEndCursor"
+	PageLimitPolicies = "policiesPageLimit"
+)
 
 type ReadSecurityPolicies struct {
-	SecurityPolicies `graphql:"securityPolicies(after: $policiesEndCursor)"`
+	SecurityPolicies `graphql:"securityPolicies(after: $policiesEndCursor, first: $policiesPageLimit)"`
 }
 
 func (q ReadSecurityPolicies) IsEmpty() bool {

--- a/twingate/internal/client/query/service-accounts-read.go
+++ b/twingate/internal/client/query/service-accounts-read.go
@@ -7,14 +7,12 @@ import (
 )
 
 const (
-	CursorServices       = "servicesEndCursor"
-	PageLimitServices    = "servicesPageLimit"
-	CursorServiceKeys    = "keysEndCursor"
-	PageLimitServiceKeys = "keysPageLimit"
+	CursorServices    = "servicesEndCursor"
+	CursorServiceKeys = "keysEndCursor"
 )
 
 type ReadServiceAccounts struct {
-	Services `graphql:"serviceAccounts(filter: $filter, after: $servicesEndCursor, first: $servicesPageLimit)"`
+	Services `graphql:"serviceAccounts(filter: $filter, after: $servicesEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadServiceAccounts) IsEmpty() bool {
@@ -37,8 +35,8 @@ type ServiceEdge struct {
 
 type GqlService struct {
 	IDName
-	Resources gqlResourceIDs `graphql:"resources(after: $resourcesEndCursor, first: $resourcesPageLimit)"`
-	Keys      gqlKeyIDs      `graphql:"keys(after: $keysEndCursor, first: $keysPageLimit)"`
+	Resources gqlResourceIDs `graphql:"resources(after: $resourcesEndCursor, first: $pageLimit)"`
+	Keys      gqlKeyIDs      `graphql:"keys(after: $keysEndCursor, first: $pageLimit)"`
 }
 
 func (s *GqlService) ToModel() *model.ServiceAccount {

--- a/twingate/internal/client/query/service-accounts-read.go
+++ b/twingate/internal/client/query/service-accounts-read.go
@@ -7,13 +7,14 @@ import (
 )
 
 const (
-	CursorServices         = "servicesEndCursor"
-	CursorServiceResources = "resourcesEndCursor"
-	CursorServiceKeys      = "keysEndCursor"
+	CursorServices       = "servicesEndCursor"
+	PageLimitServices    = "servicesPageLimit"
+	CursorServiceKeys    = "keysEndCursor"
+	PageLimitServiceKeys = "keysPageLimit"
 )
 
 type ReadServiceAccounts struct {
-	Services `graphql:"serviceAccounts(filter: $filter, after: $servicesEndCursor)"`
+	Services `graphql:"serviceAccounts(filter: $filter, after: $servicesEndCursor, first: $servicesPageLimit)"`
 }
 
 func (q ReadServiceAccounts) IsEmpty() bool {
@@ -36,8 +37,8 @@ type ServiceEdge struct {
 
 type GqlService struct {
 	IDName
-	Resources gqlResourceIDs `graphql:"resources(after: $resourcesEndCursor)"`
-	Keys      gqlKeyIDs      `graphql:"keys(after: $keysEndCursor)"`
+	Resources gqlResourceIDs `graphql:"resources(after: $resourcesEndCursor, first: $resourcesPageLimit)"`
+	Keys      gqlKeyIDs      `graphql:"keys(after: $keysEndCursor, first: $keysPageLimit)"`
 }
 
 func (s *GqlService) ToModel() *model.ServiceAccount {

--- a/twingate/internal/client/query/service-accounts-shallow-read.go
+++ b/twingate/internal/client/query/service-accounts-shallow-read.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ReadShallowServiceAccounts struct {
-	ServiceAccounts `graphql:"serviceAccounts(after: $servicesEndCursor, first: $servicesPageLimit)"`
+	ServiceAccounts `graphql:"serviceAccounts(after: $servicesEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadShallowServiceAccounts) IsEmpty() bool {

--- a/twingate/internal/client/query/service-accounts-shallow-read.go
+++ b/twingate/internal/client/query/service-accounts-shallow-read.go
@@ -5,10 +5,8 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorServiceAccounts = "serviceAccountsEndCursor"
-
 type ReadShallowServiceAccounts struct {
-	ServiceAccounts `graphql:"serviceAccounts(after: $serviceAccountsEndCursor)"`
+	ServiceAccounts `graphql:"serviceAccounts(after: $servicesEndCursor, first: $servicesPageLimit)"`
 }
 
 func (q ReadShallowServiceAccounts) IsEmpty() bool {

--- a/twingate/internal/client/query/users-read.go
+++ b/twingate/internal/client/query/users-read.go
@@ -5,10 +5,13 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const CursorUsers = "usersEndCursor"
+const (
+	CursorUsers    = "usersEndCursor"
+	PageLimitUsers = "usersPageLimit"
+)
 
 type ReadUsers struct {
-	Users `graphql:"users(after: $usersEndCursor)"`
+	Users `graphql:"users(after: $usersEndCursor, first: $usersPageLimit)"`
 }
 
 func (q ReadUsers) IsEmpty() bool {

--- a/twingate/internal/client/query/users-read.go
+++ b/twingate/internal/client/query/users-read.go
@@ -5,13 +5,10 @@ import (
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 )
 
-const (
-	CursorUsers    = "usersEndCursor"
-	PageLimitUsers = "usersPageLimit"
-)
+const CursorUsers = "usersEndCursor"
 
 type ReadUsers struct {
-	Users `graphql:"users(after: $usersEndCursor, first: $usersPageLimit)"`
+	Users `graphql:"users(after: $usersEndCursor, first: $pageLimit)"`
 }
 
 func (q ReadUsers) IsEmpty() bool {

--- a/twingate/internal/client/remote-network.go
+++ b/twingate/internal/client/remote-network.go
@@ -34,8 +34,8 @@ func (client *Client) ReadRemoteNetworks(ctx context.Context) ([]*model.RemoteNe
 	opr := resourceRemoteNetwork.read()
 
 	variables := newVars(
-		gqlNullable("", query.CursorRemoteNetworks),
-		gqlVar(client.pageLimit, query.PageLimitRemoteNetworks),
+		cursor(query.CursorRemoteNetworks),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadRemoteNetworks{}

--- a/twingate/internal/client/remote-network.go
+++ b/twingate/internal/client/remote-network.go
@@ -31,12 +31,15 @@ func (client *Client) CreateRemoteNetwork(ctx context.Context, req *model.Remote
 }
 
 func (client *Client) ReadRemoteNetworks(ctx context.Context) ([]*model.RemoteNetwork, error) {
-	op := resourceRemoteNetwork.read()
+	opr := resourceRemoteNetwork.read()
 
-	variables := newVars(gqlNullable("", query.CursorRemoteNetworks))
+	variables := newVars(
+		gqlNullable("", query.CursorRemoteNetworks),
+		gqlVar(client.pageLimit, query.PageLimitRemoteNetworks),
+	)
 
 	response := query.ReadRemoteNetworks{}
-	if err := client.query(ctx, &response, variables, op.withCustomName("readRemoteNetworks"), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readRemoteNetworks"), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 
@@ -48,12 +51,12 @@ func (client *Client) ReadRemoteNetworks(ctx context.Context) ([]*model.RemoteNe
 }
 
 func (client *Client) readRemoteNetworksAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.RemoteNetworkEdge], error) {
-	op := resourceRemoteNetwork.read()
+	opr := resourceRemoteNetwork.read()
 
 	variables[query.CursorRemoteNetworks] = cursor
 
 	response := query.ReadRemoteNetworks{}
-	if err := client.query(ctx, &response, variables, op.withCustomName("readRemoteNetworks")); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readRemoteNetworks")); err != nil {
 		return nil, err
 	}
 

--- a/twingate/internal/client/resource.go
+++ b/twingate/internal/client/resource.go
@@ -70,10 +70,9 @@ func (client *Client) CreateResource(ctx context.Context, input *model.Resource)
 		gqlNullable(input.IsVisible, "isVisible"),
 		gqlNullable(input.IsBrowserShortcutEnabled, "isBrowserShortcutEnabled"),
 		gqlNullable(input.Alias, "alias"),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
-		gqlNullable("", query.CursorGroups),
-		gqlVar(client.pageLimit, query.PageLimitGroups),
+		cursor(query.CursorUsers),
+		cursor(query.CursorGroups),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.CreateResource{}
@@ -106,10 +105,9 @@ func (client *Client) ReadResource(ctx context.Context, resourceID string) (*mod
 
 	variables := newVars(
 		gqlID(resourceID),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
-		gqlNullable("", query.CursorGroups),
-		gqlVar(client.pageLimit, query.PageLimitGroups),
+		cursor(query.CursorUsers),
+		cursor(query.CursorGroups),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadResource{}
@@ -129,8 +127,6 @@ func (client *Client) readResourceGroupsAfter(ctx context.Context, variables map
 
 	resourceID := string(variables["id"].(graphql.ID))
 	variables[query.CursorGroups] = cursor
-	variables[query.PageLimitUsers] = client.pageLimit
-	variables[query.PageLimitGroups] = client.pageLimit
 
 	if _, exists := variables[query.CursorUsers]; !exists {
 		gqlNullable("", query.CursorUsers)(variables)
@@ -148,8 +144,8 @@ func (client *Client) ReadResources(ctx context.Context) ([]*model.Resource, err
 	opr := resourceResource.read()
 
 	variables := newVars(
-		gqlNullable("", query.CursorResources),
-		gqlVar(client.pageLimit, query.PageLimitResources),
+		cursor(query.CursorResources),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadResources{}
@@ -190,10 +186,9 @@ func (client *Client) UpdateResource(ctx context.Context, input *model.Resource)
 		gqlNullable(input.IsVisible, "isVisible"),
 		gqlNullable(input.IsBrowserShortcutEnabled, "isBrowserShortcutEnabled"),
 		gqlNullable(input.Alias, "alias"),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
-		gqlNullable("", query.CursorGroups),
-		gqlVar(client.pageLimit, query.PageLimitGroups),
+		cursor(query.CursorUsers),
+		cursor(query.CursorGroups),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.UpdateResource{}
@@ -201,7 +196,8 @@ func (client *Client) UpdateResource(ctx context.Context, input *model.Resource)
 		return nil, err
 	}
 
-	if err := response.Entity.Groups.FetchPages(ctx, client.readResourceGroupsAfter, newVars(gqlID(input.ID))); err != nil {
+	if err := response.Entity.Groups.FetchPages(ctx,
+		client.readResourceGroupsAfter, newVars(pageLimit(client.pageLimit), gqlID(input.ID))); err != nil {
 		return nil, err //nolint
 	}
 
@@ -250,8 +246,8 @@ func (client *Client) ReadResourcesByName(ctx context.Context, name string) ([]*
 
 	variables := newVars(
 		gqlVar(name, "name"),
-		gqlNullable("", query.CursorResources),
-		gqlVar(client.pageLimit, query.PageLimitResources),
+		cursor(query.CursorResources),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadResourcesByName{}
@@ -336,10 +332,9 @@ func (client *Client) DeleteResourceGroups(ctx context.Context, resourceID strin
 	variables := newVars(
 		gqlID(resourceID),
 		gqlIDs(deleteGroupIDs, "removedGroupIds"),
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
-		gqlNullable("", query.CursorGroups),
-		gqlVar(client.pageLimit, query.PageLimitGroups),
+		cursor(query.CursorGroups),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.UpdateResourceRemoveGroups{}

--- a/twingate/internal/client/security-policy.go
+++ b/twingate/internal/client/security-policy.go
@@ -35,6 +35,7 @@ func (client *Client) ReadSecurityPolicies(ctx context.Context) ([]*model.Securi
 
 	variables := newVars(
 		gqlNullable("", query.CursorPolicies),
+		gqlVar(client.pageLimit, query.PageLimitPolicies),
 	)
 
 	response := query.ReadSecurityPolicies{}

--- a/twingate/internal/client/security-policy.go
+++ b/twingate/internal/client/security-policy.go
@@ -34,8 +34,8 @@ func (client *Client) ReadSecurityPolicies(ctx context.Context) ([]*model.Securi
 	opr := resourceSecurityPolicy.read()
 
 	variables := newVars(
-		gqlNullable("", query.CursorPolicies),
-		gqlVar(client.pageLimit, query.PageLimitPolicies),
+		cursor(query.CursorPolicies),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadSecurityPolicies{}

--- a/twingate/internal/client/service-account.go
+++ b/twingate/internal/client/service-account.go
@@ -87,8 +87,8 @@ func (client *Client) ReadShallowServiceAccounts(ctx context.Context) ([]*model.
 	opr := resourceServiceAccount.read()
 
 	variables := newVars(
-		gqlNullable("", query.CursorServices),
-		gqlVar(client.pageLimit, query.PageLimitServices),
+		cursor(query.CursorServices),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadShallowServiceAccounts{}
@@ -126,12 +126,10 @@ func (client *Client) ReadServiceAccounts(ctx context.Context, input ...string) 
 
 	variables := newVars(
 		gqlNullable(query.NewServiceAccountFilterInput(name), "filter"),
-		gqlNullable("", query.CursorServices),
-		gqlVar(client.pageLimit, query.PageLimitServices),
-		gqlNullable("", query.CursorResources),
-		gqlVar(client.pageLimit, query.PageLimitResources),
-		gqlNullable("", query.CursorServiceKeys),
-		gqlVar(client.pageLimit, query.PageLimitServiceKeys),
+		cursor(query.CursorServices),
+		cursor(query.CursorResources),
+		cursor(query.CursorServiceKeys),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadServiceAccounts{}
@@ -175,8 +173,6 @@ func (client *Client) readServiceResourcesAfter(ctx context.Context, variables m
 
 	gqlNullable("", query.CursorServiceKeys)(variables)
 	variables[query.CursorResources] = cursor
-	variables[query.PageLimitResources] = client.pageLimit
-	variables[query.PageLimitServiceKeys] = client.pageLimit
 
 	response := query.ReadServiceAccount{}
 	if err := client.query(ctx, &response, variables, opr.withCustomName(queryReadServices), attr{id: "All"}); err != nil {
@@ -191,8 +187,6 @@ func (client *Client) readServiceKeysAfter(ctx context.Context, variables map[st
 
 	gqlNullable("", query.CursorResources)(variables)
 	variables[query.CursorServiceKeys] = cursor
-	variables[query.PageLimitServiceKeys] = client.pageLimit
-	variables[query.PageLimitResources] = client.pageLimit
 
 	response := query.ReadServiceAccount{}
 	if err := client.query(ctx, &response, variables, opr.withCustomName(queryReadServices), attr{id: "All"}); err != nil {
@@ -211,10 +205,9 @@ func (client *Client) ReadServiceAccount(ctx context.Context, serviceAccountID s
 
 	variables := newVars(
 		gqlID(serviceAccountID),
-		gqlNullable("", query.CursorResources),
-		gqlVar(client.pageLimit, query.PageLimitResources),
-		gqlNullable("", query.CursorServiceKeys),
-		gqlVar(client.pageLimit, query.PageLimitServiceKeys),
+		cursor(query.CursorResources),
+		cursor(query.CursorServiceKeys),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadServiceAccount{}
@@ -230,7 +223,7 @@ func (client *Client) ReadServiceAccount(ctx context.Context, serviceAccountID s
 }
 
 func (client *Client) fetchServiceInternalResources(ctx context.Context, serviceAccount *query.GqlService) error {
-	vars := newVars(gqlID(serviceAccount.ID))
+	vars := newVars(gqlID(serviceAccount.ID), pageLimit(client.pageLimit))
 
 	err := serviceAccount.Resources.FetchPages(ctx, client.readServiceResourcesAfter, vars)
 	if err != nil {

--- a/twingate/internal/client/service-account.go
+++ b/twingate/internal/client/service-account.go
@@ -84,12 +84,15 @@ func (client *Client) DeleteServiceAccount(ctx context.Context, serviceAccountID
 }
 
 func (client *Client) ReadShallowServiceAccounts(ctx context.Context) ([]*model.ServiceAccount, error) {
-	op := resourceServiceAccount.read()
+	opr := resourceServiceAccount.read()
 
-	variables := newVars(gqlNullable("", query.CursorServiceAccounts))
+	variables := newVars(
+		gqlNullable("", query.CursorServices),
+		gqlVar(client.pageLimit, query.PageLimitServices),
+	)
 
 	response := query.ReadShallowServiceAccounts{}
-	if err := client.query(ctx, &response, variables, op, attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr, attr{id: "All"}); err != nil {
 		return nil, err
 	}
 
@@ -101,12 +104,12 @@ func (client *Client) ReadShallowServiceAccounts(ctx context.Context) ([]*model.
 }
 
 func (client *Client) readServiceAccountsAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.ServiceAccountEdge], error) {
-	op := resourceServiceAccount.read()
+	opr := resourceServiceAccount.read()
 
-	variables[query.CursorServiceAccounts] = cursor
+	variables[query.CursorServices] = cursor
 
 	response := query.ReadShallowServiceAccounts{}
-	if err := client.query(ctx, &response, variables, op.withCustomName(queryReadServiceAccounts), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName(queryReadServiceAccounts), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 
@@ -124,8 +127,11 @@ func (client *Client) ReadServiceAccounts(ctx context.Context, input ...string) 
 	variables := newVars(
 		gqlNullable(query.NewServiceAccountFilterInput(name), "filter"),
 		gqlNullable("", query.CursorServices),
-		gqlNullable("", query.CursorServiceResources),
+		gqlVar(client.pageLimit, query.PageLimitServices),
+		gqlNullable("", query.CursorResources),
+		gqlVar(client.pageLimit, query.PageLimitResources),
 		gqlNullable("", query.CursorServiceKeys),
+		gqlVar(client.pageLimit, query.PageLimitServiceKeys),
 	)
 
 	response := query.ReadServiceAccounts{}
@@ -152,12 +158,12 @@ func (client *Client) ReadServiceAccounts(ctx context.Context, input ...string) 
 }
 
 func (client *Client) readServicesAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.ServiceEdge], error) {
-	op := resourceServiceAccount.read()
+	opr := resourceServiceAccount.read()
 
 	variables[query.CursorServices] = cursor
 
 	response := query.ReadServiceAccounts{}
-	if err := client.query(ctx, &response, variables, op.withCustomName(queryReadServices), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName(queryReadServices), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 
@@ -168,7 +174,9 @@ func (client *Client) readServiceResourcesAfter(ctx context.Context, variables m
 	opr := resourceServiceAccount.read()
 
 	gqlNullable("", query.CursorServiceKeys)(variables)
-	variables[query.CursorServiceResources] = cursor
+	variables[query.CursorResources] = cursor
+	variables[query.PageLimitResources] = client.pageLimit
+	variables[query.PageLimitServiceKeys] = client.pageLimit
 
 	response := query.ReadServiceAccount{}
 	if err := client.query(ctx, &response, variables, opr.withCustomName(queryReadServices), attr{id: "All"}); err != nil {
@@ -181,8 +189,10 @@ func (client *Client) readServiceResourcesAfter(ctx context.Context, variables m
 func (client *Client) readServiceKeysAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.GqlKeyIDEdge], error) {
 	opr := resourceServiceAccount.read()
 
-	gqlNullable("", query.CursorServiceResources)(variables)
+	gqlNullable("", query.CursorResources)(variables)
 	variables[query.CursorServiceKeys] = cursor
+	variables[query.PageLimitServiceKeys] = client.pageLimit
+	variables[query.PageLimitResources] = client.pageLimit
 
 	response := query.ReadServiceAccount{}
 	if err := client.query(ctx, &response, variables, opr.withCustomName(queryReadServices), attr{id: "All"}); err != nil {
@@ -201,8 +211,10 @@ func (client *Client) ReadServiceAccount(ctx context.Context, serviceAccountID s
 
 	variables := newVars(
 		gqlID(serviceAccountID),
-		gqlNullable("", query.CursorServiceResources),
+		gqlNullable("", query.CursorResources),
+		gqlVar(client.pageLimit, query.PageLimitResources),
 		gqlNullable("", query.CursorServiceKeys),
+		gqlVar(client.pageLimit, query.PageLimitServiceKeys),
 	)
 
 	response := query.ReadServiceAccount{}

--- a/twingate/internal/client/user.go
+++ b/twingate/internal/client/user.go
@@ -12,8 +12,8 @@ func (client *Client) ReadUsers(ctx context.Context) ([]*model.User, error) {
 	opr := resourceUser.read()
 
 	variables := newVars(
-		gqlNullable("", query.CursorUsers),
-		gqlVar(client.pageLimit, query.PageLimitUsers),
+		cursor(query.CursorUsers),
+		pageLimit(client.pageLimit),
 	)
 
 	response := query.ReadUsers{}

--- a/twingate/internal/client/user.go
+++ b/twingate/internal/client/user.go
@@ -9,12 +9,15 @@ import (
 )
 
 func (client *Client) ReadUsers(ctx context.Context) ([]*model.User, error) {
-	op := resourceUser.read()
+	opr := resourceUser.read()
 
-	variables := newVars(gqlNullable("", query.CursorUsers))
+	variables := newVars(
+		gqlNullable("", query.CursorUsers),
+		gqlVar(client.pageLimit, query.PageLimitUsers),
+	)
 
 	response := query.ReadUsers{}
-	if err := client.query(ctx, &response, variables, op.withCustomName("readUsers"), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readUsers"), attr{id: "All"}); err != nil {
 		if errors.Is(err, ErrGraphqlResultIsEmpty) {
 			return nil, nil
 		}
@@ -30,12 +33,12 @@ func (client *Client) ReadUsers(ctx context.Context) ([]*model.User, error) {
 }
 
 func (client *Client) readUsersAfter(ctx context.Context, variables map[string]interface{}, cursor string) (*query.PaginatedResource[*query.UserEdge], error) {
-	op := resourceUser.read()
+	opr := resourceUser.read()
 
 	variables[query.CursorUsers] = cursor
 	response := query.ReadUsers{}
 
-	if err := client.query(ctx, &response, variables, op.withCustomName("readUsers"), attr{id: "All"}); err != nil {
+	if err := client.query(ctx, &response, variables, opr.withCustomName("readUsers"), attr{id: "All"}); err != nil {
 		return nil, err
 	}
 

--- a/twingate/internal/client/variables.go
+++ b/twingate/internal/client/variables.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/Twingate/terraform-provider-twingate/twingate/internal/client/query"
 	"github.com/Twingate/terraform-provider-twingate/twingate/internal/utils"
 	"github.com/hasura/go-graphql-client"
 )
@@ -16,6 +17,14 @@ func newVars(options ...gqlVarOption) map[string]interface{} {
 }
 
 type gqlVarOption func(values map[string]interface{}) map[string]interface{}
+
+func pageLimit(limit int) gqlVarOption {
+	return gqlVar(limit, query.PageLimit)
+}
+
+func cursor(name string) gqlVarOption {
+	return gqlNullable("", name)
+}
 
 func gqlID(val interface{}, name ...string) gqlVarOption {
 	key := "id"

--- a/twingate/internal/test/acctests/datasource/connectors_test.go
+++ b/twingate/internal/test/acctests/datasource/connectors_test.go
@@ -15,6 +15,8 @@ import (
 
 func TestAccDatasourceTwingateConnectors_basic(t *testing.T) {
 	t.Run("Test Twingate Datasource : Acc Connectors Basic", func(t *testing.T) {
+		acctests.SetPageLimit(1)
+
 		networkName1 := test.RandomName()
 		networkName2 := test.RandomName()
 		connectorName := test.RandomConnectorName()

--- a/twingate/internal/test/acctests/datasource/groups_test.go
+++ b/twingate/internal/test/acctests/datasource/groups_test.go
@@ -96,6 +96,7 @@ func testTwingateGroupsDoesNotExists(name string) string {
 }
 
 func TestAccDatasourceTwingateGroupsWithFilters_basic(t *testing.T) {
+	acctests.SetPageLimit(1)
 	groupName := test.RandomName()
 
 	const theDatasource = "data.twingate_groups.out_dgs2"

--- a/twingate/internal/test/acctests/datasource/remote-networks_test.go
+++ b/twingate/internal/test/acctests/datasource/remote-networks_test.go
@@ -36,6 +36,8 @@ func testDatasourceTwingateRemoteNetworks() string {
 
 func TestAccDatasourceTwingateRemoteNetworks_read(t *testing.T) {
 	t.Run("Test Twingate Datasource : Acc Remote Networks Read", func(t *testing.T) {
+		acctests.SetPageLimit(1)
+
 		prefix := acctest.RandString(10)
 		networkName1 := test.RandomName(prefix)
 		networkName2 := test.RandomName(prefix)

--- a/twingate/internal/test/acctests/datasource/resources_test.go
+++ b/twingate/internal/test/acctests/datasource/resources_test.go
@@ -17,7 +17,7 @@ var (
 
 func TestAccDatasourceTwingateResources_basic(t *testing.T) {
 	t.Run("Test Twingate Datasource : Acc Resources Basic", func(t *testing.T) {
-
+		acctests.SetPageLimit(1)
 		networkName := test.RandomName()
 		resourceName := test.RandomResourceName()
 		const theDatasource = "data.twingate_resources.out_drs1"

--- a/twingate/internal/test/acctests/datasource/security-policies_test.go
+++ b/twingate/internal/test/acctests/datasource/security-policies_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestAccDatasourceTwingateSecurityPoliciesBasic(t *testing.T) {
 	t.Run("Test Twingate Datasource : Acc Security Policies - basic", func(t *testing.T) {
+		acctests.SetPageLimit(1)
+
 		securityPolicies, err := acctests.ListSecurityPolicies()
 		if err != nil {
 			t.Skip("can't run test:", err)

--- a/twingate/internal/test/acctests/datasource/service-accounts_test.go
+++ b/twingate/internal/test/acctests/datasource/service-accounts_test.go
@@ -61,7 +61,7 @@ func TestAccDatasourceTwingateServicesFilterByName(t *testing.T) {
 
 func TestAccDatasourceTwingateServicesAll(t *testing.T) {
 	t.Run("Test Twingate Datasource : Acc Services - All", func(t *testing.T) {
-
+		acctests.SetPageLimit(1)
 		prefix := test.Prefix() + acctest.RandString(4)
 		const (
 			terraformResourceName = "dts_service"

--- a/twingate/internal/test/acctests/datasource/service-accounts_test.go
+++ b/twingate/internal/test/acctests/datasource/service-accounts_test.go
@@ -196,3 +196,120 @@ func filterDatasourceServices(prefix string, configs []terraformServiceConfig) s
 	}
 	`, createServices(configs), prefix)
 }
+
+func TestAccDatasourceTwingateServicesAllCursors(t *testing.T) {
+	t.Run("Test Twingate Datasource : Acc Services - All Cursors", func(t *testing.T) {
+		acctests.SetPageLimit(1)
+		prefix := test.Prefix() + acctest.RandString(4)
+		const (
+			theDatasource = "data.twingate_service_accounts.out"
+		)
+
+		resource.Test(t, resource.TestCase{
+			ProviderFactories: acctests.ProviderFactories,
+			PreCheck:          func() { acctests.PreCheck(t) },
+			CheckDestroy:      acctests.CheckTwingateServiceAccountDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: datasourceServicesConfig(prefix),
+					Check: acctests.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(theDatasource, attr.ID, "all-services"),
+					),
+				},
+				{
+					Config: datasourceServicesConfig(prefix),
+					Check: acctests.ComposeTestCheckFunc(
+						testCheckOutputLength("my_services", 3),
+						testCheckOutputNestedLen("my_services", 0, attr.ResourceIDs, 1),
+						testCheckOutputNestedLen("my_services", 0, attr.KeyIDs, 2),
+					),
+				},
+			},
+		})
+	})
+}
+
+func datasourceServicesConfig(prefix string) string {
+	return fmt.Sprintf(`
+    resource "twingate_service_account" "%s_1" {
+      name = "%s-1"
+    }
+    
+    resource "twingate_service_account" "%s_2" {
+      name = "%s-2"
+    }
+
+    resource "twingate_service_account" "%s_3" {
+      name = "%s-3"
+    }
+    
+    resource "twingate_remote_network" "%s_1" {
+      name = "%s-1"
+    }
+    
+    resource "twingate_remote_network" "%s_2" {
+      name = "%s-2"
+    }
+    
+    resource "twingate_resource" "%s_1" {
+      name = "%s-1"
+      address = "acc-test.com"
+      remote_network_id = twingate_remote_network.%s_1.id
+    
+      access {
+        service_account_ids = [twingate_service_account.%s_1.id, twingate_service_account.%s_2.id]
+      }
+    }
+    
+    resource "twingate_resource" "%s_2" {
+      name = "%s-2"
+      address = "acc-test.com"
+      remote_network_id = twingate_remote_network.%s_2.id
+    
+      access {
+        service_account_ids = [twingate_service_account.%s_3.id]
+      }
+    }
+    
+    resource "twingate_service_account_key" "%s_1_1" {
+      service_account_id = twingate_service_account.%s_1.id
+    }
+    
+    resource "twingate_service_account_key" "%s_1_2" {
+      service_account_id = twingate_service_account.%s_1.id
+    }
+    
+    resource "twingate_service_account_key" "%s_2_1" {
+      service_account_id = twingate_service_account.%s_2.id
+    }
+    
+    resource "twingate_service_account_key" "%s_2_2" {
+      service_account_id = twingate_service_account.%s_2.id
+    }
+    
+    resource "twingate_service_account_key" "%s_3_1" {
+      service_account_id = twingate_service_account.%s_3.id
+    }
+
+    resource "twingate_service_account_key" "%s_3_2" {
+      service_account_id = twingate_service_account.%s_3.id
+    }
+    
+    data "twingate_service_accounts" "out" {
+    
+    }
+    
+    output "my_services" {
+      value = [for c in data.twingate_service_accounts.out.service_accounts : c if length(regexall("^%s", c.name)) > 0]
+    }
+`, duplicate(prefix, 32)...)
+}
+
+func duplicate(val string, n int) []any {
+	result := make([]any, 0, n)
+	for i := 0; i < n; i++ {
+		result = append(result, val)
+	}
+
+	return result
+}

--- a/twingate/internal/test/acctests/datasource/users_test.go
+++ b/twingate/internal/test/acctests/datasource/users_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccDatasourceTwingateUsers_basic(t *testing.T) {
 	t.Run("Test Twingate Datasource : Acc Users Basic", func(t *testing.T) {
+		acctests.SetPageLimit(1)
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: acctests.ProviderFactories,
 			PreCheck:          func() { acctests.PreCheck(t) },

--- a/twingate/internal/test/acctests/helper.go
+++ b/twingate/internal/test/acctests/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -51,6 +52,12 @@ func init() {
 		"twingate": func() (*schema.Provider, error) {
 			return Provider, nil
 		},
+	}
+}
+
+func SetPageLimit(limit int) {
+	if err := os.Setenv(client.EnvPageLimit, fmt.Sprintf("%d", limit)); err != nil {
+		log.Fatal("failed to set page limit", err)
 	}
 }
 

--- a/twingate/internal/test/acctests/resource/group_test.go
+++ b/twingate/internal/test/acctests/resource/group_test.go
@@ -355,3 +355,46 @@ func TestAccTwingateGroupUsersNotAuthoritative(t *testing.T) {
 		})
 	})
 }
+
+func TestAccTwingateGroupUsersCursor(t *testing.T) {
+	t.Run("Test Twingate Resource : Acc Group Users Cursor", func(t *testing.T) {
+		acctests.SetPageLimit(1)
+
+		const terraformResourceName = "test007"
+		theResource := acctests.TerraformGroup(terraformResourceName)
+		groupName := test.RandomName()
+
+		users, err := acctests.GetTestUsers()
+		if err != nil {
+			t.Skip("can't run test:", err)
+		}
+
+		usersID := utils.Map(users, func(user *model.User) string {
+			return user.ID
+		})
+
+		if len(usersID) < 4 {
+			t.Skip("can't run test: not enough users")
+		}
+
+		sdk.Test(t, sdk.TestCase{
+			ProviderFactories: acctests.ProviderFactories,
+			PreCheck:          func() { acctests.PreCheck(t) },
+			CheckDestroy:      acctests.CheckTwingateGroupDestroy,
+			Steps: []sdk.TestStep{
+				{
+					Config: terraformResourceTwingateGroupWithUsers(terraformResourceName, groupName, usersID),
+					Check: acctests.ComposeTestCheckFunc(
+						acctests.CheckGroupUsersLen(theResource, len(usersID)),
+					),
+				},
+				{
+					Config: terraformResourceTwingateGroupWithUsers(terraformResourceName, groupName, usersID[:3]),
+					Check: acctests.ComposeTestCheckFunc(
+						acctests.CheckGroupUsersLen(theResource, 3),
+					),
+				},
+			},
+		})
+	})
+}

--- a/twingate/internal/test/acctests/resource/resource_test.go
+++ b/twingate/internal/test/acctests/resource/resource_test.go
@@ -1783,8 +1783,6 @@ func createResource29WithoutAlias(terraformResourceName, networkName, resourceNa
 	`, terraformResourceName, networkName, terraformResourceName, resourceName, terraformResourceName)
 }
 
-// usersID := []string{"VXNlcjoxNDEwMA==", "VXNlcjoxNDEwMQ==", "VXNlcjoxNjU1NA==", "VXNlcjoxNjU1NQ=="}
-
 func TestAccTwingateResourceGroupsCursor(t *testing.T) {
 	acctests.SetPageLimit(1)
 

--- a/twingate/internal/test/acctests/resource/resource_test.go
+++ b/twingate/internal/test/acctests/resource/resource_test.go
@@ -1782,3 +1782,75 @@ func createResource29WithoutAlias(terraformResourceName, networkName, resourceNa
 	}
 	`, terraformResourceName, networkName, terraformResourceName, resourceName, terraformResourceName)
 }
+
+// usersID := []string{"VXNlcjoxNDEwMA==", "VXNlcjoxNDEwMQ==", "VXNlcjoxNjU1NA==", "VXNlcjoxNjU1NQ=="}
+
+func TestAccTwingateResourceGroupsCursor(t *testing.T) {
+	acctests.SetPageLimit(1)
+
+	const terraformResourceName = "test27"
+	theResource := acctests.TerraformResource(terraformResourceName)
+	remoteNetworkName := test.RandomName()
+	resourceName := test.RandomResourceName()
+	groups, groupsID := genNewGroups("g27", 3)
+	serviceAccounts, serviceAccountIDs := genNewServiceAccounts("s27", 3)
+
+	sdk.Test(t, sdk.TestCase{
+		ProviderFactories: acctests.ProviderFactories,
+		PreCheck:          func() { acctests.PreCheck(t) },
+		CheckDestroy:      acctests.CheckTwingateResourceDestroy,
+		Steps: []sdk.TestStep{
+			{
+				Config: createResourceWithGroupsAndServiceAccounts(terraformResourceName, remoteNetworkName, resourceName, groups, groupsID, serviceAccounts, serviceAccountIDs),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+					sdk.TestCheckResourceAttr(theResource, accessGroupIdsLen, "3"),
+					sdk.TestCheckResourceAttr(theResource, accessServiceAccountIdsLen, "3"),
+				),
+			},
+			{
+				Config: createResourceWithGroupsAndServiceAccounts(terraformResourceName, remoteNetworkName, resourceName, groups, groupsID[:2], serviceAccounts, serviceAccountIDs[:2]),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+					sdk.TestCheckResourceAttr(theResource, accessGroupIdsLen, "2"),
+					sdk.TestCheckResourceAttr(theResource, accessServiceAccountIdsLen, "2"),
+				),
+			},
+		},
+	})
+}
+
+func createResourceWithGroupsAndServiceAccounts(name, networkName, resourceName string, groups, groupsID, serviceAccounts, serviceAccountIDs []string) string {
+	return fmt.Sprintf(`
+	resource "twingate_remote_network" "%s" {
+	  name = "%s"
+	}
+
+	%s
+
+	%s
+
+	resource "twingate_resource" "%s" {
+	  name = "%s"
+	  address = "acc-test.com.26"
+	  remote_network_id = twingate_remote_network.%s.id
+	  
+	  protocols {
+	    allow_icmp = true
+	    tcp {
+	      policy = "%s"
+	      ports = ["80", "82-83"]
+	    }
+	    udp {
+	      policy = "%s"
+	    }
+	  }
+
+	  access {
+	    group_ids = [%s]
+	    service_account_ids = [%s]
+	  }
+
+	}
+	`, name, networkName, strings.Join(groups, "\n"), strings.Join(serviceAccounts, "\n"), name, resourceName, name, model.PolicyRestricted, model.PolicyAllowAll, strings.Join(groupsID, ", "), strings.Join(serviceAccountIDs, ", "))
+}


### PR DESCRIPTION
## Changes
- updated graphql queries: added cursors and page limit
- added tests with page limit = 1 (which enforces usage of cursors and helper func to fetch next page)
