### PR TITLE
Dont Smoke-Test terraform versions no longer supported

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -45,6 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
+          - '1.2.*'
+          - '1.3.*'
           - '1.4.*'
           - '1.5.*'
           - 'latest'

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -45,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.2.*'
-          - '1.3.*'
+          - '1.4.*'
+          - '1.5.*'
           - 'latest'
     steps:
     - name: Check out code into the Go module directory


### PR DESCRIPTION
## Changes
- `latest` moved to be 1.5 but we still want to tst on 1.4. So this explicitly lists all versions we currently support


<img width="1034" alt="Screenshot 2023-06-20 at 1 06 57 PM" src="https://github.com/Twingate/terraform-provider-twingate/assets/205185/16847b3e-4b97-448e-a9d9-37531bc387e3">
