### PR TITLE
Change timeout to 35s

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ from the Twingate Admin Console ([documentation](https://docs.twingate.com/docs/
 Alternatively, this can be specified using the TWINGATE_API_TOKEN environment variable.
 - `http_max_retry` (Number) Specifies a retry limit for the http requests made. The default value is 10.
 Alternatively, this can be specified using the TWINGATE_HTTP_MAX_RETRY environment variable
-- `http_timeout` (Number) Specifies a time limit in seconds for the http requests made. The default value is 10 seconds.
+- `http_timeout` (Number) Specifies a time limit in seconds for the http requests made. The default value is 35 seconds.
 Alternatively, this can be specified using the TWINGATE_HTTP_TIMEOUT environment variable
 - `network` (String) Your Twingate network ID for API operations.
 You can find it in the Admin Console URL, for example:

--- a/twingate/provider.go
+++ b/twingate/provider.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultHTTPTimeout  = "10"
+	DefaultHTTPTimeout  = "35"
 	DefaultHTTPMaxRetry = "10"
 	DefaultURL          = "twingate.com"
 

--- a/twingate/v2/provider.go
+++ b/twingate/v2/provider.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	DefaultHTTPTimeout  = "10"
+	DefaultHTTPTimeout  = "35"
 	DefaultHTTPMaxRetry = "10"
 	DefaultURL          = "twingate.com"
 


### PR DESCRIPTION
Resolves #403 

## Changes
- Changing the default timeout to `35s` until we have a better solution for idepotency 
