### PR TITLE
Update AWS docs

### DIFF
--- a/docs/guides/aws-deployment-guide.md
+++ b/docs/guides/aws-deployment-guide.md
@@ -71,7 +71,7 @@ Now, let's go ahead and deploy the AMI. For this example, we're creating a new V
 # define or use an existing VPC
 module "demo_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+  version = "~> 5.8"
 
   name = "demo_vpc"
   cidr = "10.0.0.0/16"
@@ -79,29 +79,27 @@ module "demo_vpc" {
   azs                            = ["us-east-1a"]
   private_subnets                = ["10.0.1.0/24"]
   public_subnets                 = ["10.0.2.0/24"]
-  enable_classiclink_dns_support = true
   enable_dns_hostnames           = true
   enable_nat_gateway             = true
-
 }
 
 # If you use an existing Security group, the Connector requires egress traffic enabled but does not require ingress
 module "demo_sg" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
-  vpc_id  = module.demo_vpc.vpc_id
-  name    = "demo_security_group"
+  source             = "terraform-aws-modules/security-group/aws"
+  version            = "~> 5.1"
+  vpc_id             = module.demo_vpc.vpc_id
+  name               = "demo_security_group"
   egress_cidr_blocks = ["0.0.0.0/0"]
-  egress_rules = ["all-tcp", "all-udp", "all-icmp"]
+  egress_rules       = ["all-tcp", "all-udp", "all-icmp"]
 }
 
 # spin off a ec2 instance from Twingate AMI and configure tokens in user_data
 module "ec2_tenant_connector" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "2.19.0"
+  version = "~> 5.6"
 
-  name = "demo_connector"
-  user_data = <<-EOT
+  name                   = "demo_connector"
+  user_data              = <<-EOT
     #!/bin/bash
     set -e
     mkdir -p /etc/twingate/
@@ -114,8 +112,14 @@ module "ec2_tenant_connector" {
   EOT
   ami                    = data.aws_ami.latest.id
   instance_type          = "t3a.micro"
-  vpc_security_group_ids = [module.demo_sg.this_security_group_id]
+  vpc_security_group_ids = [module.demo_sg.security_group_id]
   subnet_id              = module.demo_vpc.private_subnets[0]
+
+  root_block_device = [
+    {
+      encrypted = true
+    }
+  ]
 }
 ```
 

--- a/docs/guides/aws-deployment-guide.md
+++ b/docs/guides/aws-deployment-guide.md
@@ -76,11 +76,11 @@ module "demo_vpc" {
   name = "demo_vpc"
   cidr = "10.0.0.0/16"
 
-  azs                            = ["us-east-1a"]
-  private_subnets                = ["10.0.1.0/24"]
-  public_subnets                 = ["10.0.2.0/24"]
-  enable_dns_hostnames           = true
-  enable_nat_gateway             = true
+  azs                  = ["us-east-1a"]
+  private_subnets      = ["10.0.1.0/24"]
+  public_subnets       = ["10.0.2.0/24"]
+  enable_dns_hostnames = true
+  enable_nat_gateway   = true
 }
 
 # If you use an existing Security group, the Connector requires egress traffic enabled but does not require ingress

--- a/examples/ami/ami.tf
+++ b/examples/ami/ami.tf
@@ -1,37 +1,35 @@
 # define or use an existing VPC
 module "demo_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+  version = "~> 5.8"
 
   name = "demo_vpc"
   cidr = "10.0.0.0/16"
 
-  azs                            = ["us-east-1a"]
-  private_subnets                = ["10.0.1.0/24"]
-  public_subnets                 = ["10.0.2.0/24"]
-  enable_classiclink_dns_support = true
-  enable_dns_hostnames           = true
-  enable_nat_gateway             = true
-
+  azs                  = ["us-east-1a"]
+  private_subnets      = ["10.0.1.0/24"]
+  public_subnets       = ["10.0.2.0/24"]
+  enable_dns_hostnames = true
+  enable_nat_gateway   = true
 }
 
 # If you use an existing Security group, the Connector requires egress traffic enabled but does not require ingress
 module "demo_sg" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
-  vpc_id  = module.demo_vpc.vpc_id
-  name    = "demo_security_group"
+  source             = "terraform-aws-modules/security-group/aws"
+  version            = "~> 5.1"
+  vpc_id             = module.demo_vpc.vpc_id
+  name               = "demo_security_group"
   egress_cidr_blocks = ["0.0.0.0/0"]
-  egress_rules = ["all-tcp", "all-udp", "all-icmp"]
+  egress_rules       = ["all-tcp", "all-udp", "all-icmp"]
 }
 
 # spin off a ec2 instance from Twingate AMI and configure tokens in user_data
 module "ec2_tenant_connector" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "2.19.0"
+  version = "~> 5.6"
 
-  name = "demo_connector"
-  user_data = <<-EOT
+  name                   = "demo_connector"
+  user_data              = <<-EOT
     #!/bin/bash
     set -e
     mkdir -p /etc/twingate/
@@ -44,6 +42,12 @@ module "ec2_tenant_connector" {
   EOT
   ami                    = data.aws_ami.latest.id
   instance_type          = "t3a.micro"
-  vpc_security_group_ids = [module.demo_sg.this_security_group_id]
+  vpc_security_group_ids = [module.demo_sg.security_group_id]
   subnet_id              = module.demo_vpc.private_subnets[0]
+
+  root_block_device = [
+    {
+      encrypted = true
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #525

## Changes
- Update AWS modules with newer versions
- Remove enable_classiclink_dns_support it is no longer supported by AWS
- Add default encryption to root EBS volume
- Minor fixes to support newer versions of modules
