### PR TITLE
Fix CIDR regex

### DIFF
--- a/twingate/internal/provider/resource/resource.go
+++ b/twingate/internal/provider/resource/resource.go
@@ -1297,7 +1297,7 @@ func (m caseInsensitiveDiffModifier) PlanModifyString(ctx context.Context, req p
 	}
 }
 
-var cidrRgxp = regexp.MustCompile(`(\d{1,3}\.){3}\d{1,3}(/\d+)?`)
+var cidrRgxp = regexp.MustCompile(`(\d{1,3}\.){3}\d{1,3}(/\d+)`)
 
 func isWildcardAddress(address string) bool {
 	return strings.ContainsAny(address, "*?") || cidrRgxp.MatchString(address)

--- a/twingate/internal/test/acctests/resource/resource_test.go
+++ b/twingate/internal/test/acctests/resource/resource_test.go
@@ -2697,7 +2697,7 @@ func TestAccTwingateResourceWithBrowserOptionIP(t *testing.T) {
 	theResource := acctests.TerraformResource(terraformResourceName)
 	remoteNetworkName := test.RandomName()
 	resourceName := test.RandomResourceName()
-	wildcardAddress := "10.0.0.1"
+	ipAddress := "10.0.0.1"
 
 	sdk.Test(t, sdk.TestCase{
 		ProtoV6ProviderFactories: acctests.ProviderFactories,
@@ -2705,19 +2705,19 @@ func TestAccTwingateResourceWithBrowserOptionIP(t *testing.T) {
 		CheckDestroy:             acctests.CheckTwingateResourceDestroy,
 		Steps: []sdk.TestStep{
 			{
-				Config: createResourceWithoutBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress),
+				Config: createResourceWithoutBrowserOption(terraformResourceName, remoteNetworkName, resourceName, ipAddress),
 				Check: acctests.ComposeTestCheckFunc(
 					acctests.CheckTwingateResourceExists(theResource),
 				),
 			},
 			{
-				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, false),
+				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, ipAddress, false),
 				Check: acctests.ComposeTestCheckFunc(
 					acctests.CheckTwingateResourceExists(theResource),
 				),
 			},
 			{
-				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, true),
+				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, ipAddress, true),
 				Check: acctests.ComposeTestCheckFunc(
 					acctests.CheckTwingateResourceExists(theResource),
 				),
@@ -2731,7 +2731,7 @@ func TestAccTwingateResourceWithBrowserOptionCIDR(t *testing.T) {
 	theResource := acctests.TerraformResource(terraformResourceName)
 	remoteNetworkName := test.RandomName()
 	resourceName := test.RandomResourceName()
-	wildcardAddress := "10.0.0.0/24"
+	cidrAddress := "10.0.0.0/24"
 
 	sdk.Test(t, sdk.TestCase{
 		ProtoV6ProviderFactories: acctests.ProviderFactories,
@@ -2739,19 +2739,19 @@ func TestAccTwingateResourceWithBrowserOptionCIDR(t *testing.T) {
 		CheckDestroy:             acctests.CheckTwingateResourceDestroy,
 		Steps: []sdk.TestStep{
 			{
-				Config: createResourceWithoutBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress),
+				Config: createResourceWithoutBrowserOption(terraformResourceName, remoteNetworkName, resourceName, cidrAddress),
 				Check: acctests.ComposeTestCheckFunc(
 					acctests.CheckTwingateResourceExists(theResource),
 				),
 			},
 			{
-				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, false),
+				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, cidrAddress, false),
 				Check: acctests.ComposeTestCheckFunc(
 					acctests.CheckTwingateResourceExists(theResource),
 				),
 			},
 			{
-				Config:      createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, true),
+				Config:      createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, cidrAddress, true),
 				ExpectError: regexp.MustCompile("Resources with a CIDR range or wildcard"),
 			},
 		},

--- a/twingate/internal/test/acctests/resource/resource_test.go
+++ b/twingate/internal/test/acctests/resource/resource_test.go
@@ -2717,7 +2717,7 @@ func TestAccTwingateResourceWithBrowserOptionIP(t *testing.T) {
 				),
 			},
 			{
-				Config:      createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, true),
+				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, true),
 				Check: acctests.ComposeTestCheckFunc(
 					acctests.CheckTwingateResourceExists(theResource),
 				),

--- a/twingate/internal/test/acctests/resource/resource_test.go
+++ b/twingate/internal/test/acctests/resource/resource_test.go
@@ -2692,6 +2692,72 @@ func TestAccTwingateResourceWithBrowserOptionRecovered(t *testing.T) {
 	})
 }
 
+func TestAccTwingateResourceWithBrowserOptionIP(t *testing.T) {
+	const terraformResourceName = "testIPWithBrowserOption"
+	theResource := acctests.TerraformResource(terraformResourceName)
+	remoteNetworkName := test.RandomName()
+	resourceName := test.RandomResourceName()
+	wildcardAddress := "10.0.0.1"
+
+	sdk.Test(t, sdk.TestCase{
+		ProtoV6ProviderFactories: acctests.ProviderFactories,
+		PreCheck:                 func() { acctests.PreCheck(t) },
+		CheckDestroy:             acctests.CheckTwingateResourceDestroy,
+		Steps: []sdk.TestStep{
+			{
+				Config: createResourceWithoutBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+				),
+			},
+			{
+				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, false),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+				),
+			},
+			{
+				Config:      createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, true),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTwingateResourceWithBrowserOptionCIDR(t *testing.T) {
+	const terraformResourceName = "testCIDRWithBrowserOption"
+	theResource := acctests.TerraformResource(terraformResourceName)
+	remoteNetworkName := test.RandomName()
+	resourceName := test.RandomResourceName()
+	wildcardAddress := "10.0.0.0/24"
+
+	sdk.Test(t, sdk.TestCase{
+		ProtoV6ProviderFactories: acctests.ProviderFactories,
+		PreCheck:                 func() { acctests.PreCheck(t) },
+		CheckDestroy:             acctests.CheckTwingateResourceDestroy,
+		Steps: []sdk.TestStep{
+			{
+				Config: createResourceWithoutBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+				),
+			},
+			{
+				Config: createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, false),
+				Check: acctests.ComposeTestCheckFunc(
+					acctests.CheckTwingateResourceExists(theResource),
+				),
+			},
+			{
+				Config:      createResourceWithBrowserOption(terraformResourceName, remoteNetworkName, resourceName, wildcardAddress, true),
+				ExpectError: regexp.MustCompile("Resources with a CIDR range or wildcard"),
+			},
+		},
+	})
+}
+
 func createResourceWithoutBrowserOption(name, networkName, resourceName, address string) string {
 	return fmt.Sprintf(`
 	resource "twingate_remote_network" "%[1]s" {


### PR DESCRIPTION
The previous CIDR regex ended with a `?` after the group capturing the slash character. I've removed the `?` and added tests to ensure that Resources with a normal IP address can be created with the browser flag.

Resolves #545 