### PR TITLE
Updated group query names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - 'README.md'
     branches:
       - main
+      - fix/operation-query-name
 
 # Ensures only 1 action runs per PR and previous is canceled on new trigger
 concurrency:

--- a/twingate/internal/client/group.go
+++ b/twingate/internal/client/group.go
@@ -71,7 +71,7 @@ func (client *Client) ReadGroup(ctx context.Context, groupID string) (*model.Gro
 }
 
 func (client *Client) ReadGroups(ctx context.Context, filter *model.GroupsFilter) ([]*model.Group, error) {
-	opr := resourceGroup.read().withCustomName("datasource_readGroups")
+	opr := resourceGroup.read().withCustomName("readGroups")
 
 	variables := newVars(
 		gqlNullable(query.NewGroupFilterInput(filter), "filter"),

--- a/twingate/internal/provider/datasource/all-datasources.go
+++ b/twingate/internal/provider/datasource/all-datasources.go
@@ -18,4 +18,6 @@ const (
 	computedDatasourceIDDescription = "The ID of this resource."
 
 	operationRead = "read"
+
+	datasourceKey = "datasource"
 )

--- a/twingate/internal/provider/datasource/group.go
+++ b/twingate/internal/provider/datasource/group.go
@@ -91,7 +91,7 @@ func (d *group) Read(ctx context.Context, req datasource.ReadRequest, resp *data
 		return
 	}
 
-	group, err := d.client.ReadGroup(ctx, data.ID.ValueString())
+	group, err := d.client.ReadGroup(client.WithCallerCtx(ctx, datasourceKey), data.ID.ValueString())
 	if err != nil {
 		addErr(&resp.Diagnostics, err, TwingateGroup)
 

--- a/twingate/internal/provider/datasource/groups.go
+++ b/twingate/internal/provider/datasource/groups.go
@@ -162,7 +162,7 @@ func (d *groups) Read(ctx context.Context, req datasource.ReadRequest, resp *dat
 
 	filter := buildFilter(&data)
 
-	groups, err := d.client.ReadGroups(ctx, filter)
+	groups, err := d.client.ReadGroups(client.WithCallerCtx(ctx, datasourceKey), filter)
 	if err != nil && !errors.Is(err, client.ErrGraphqlResultIsEmpty) {
 		addErr(&resp.Diagnostics, err, TwingateGroups)
 


### PR DESCRIPTION
## Changes
- update group query names

use cases:

1. Group resource
  1. Init cache at beginning of provider: op will be `cache_readGroups` for first call and then `cache_readGroups_readGroupsAfter` for all pages
  2. Create a group and read it after - op name is just `readGroup`
2. Group datasource (singular) - op name is `datasource_readGroup`
3. Group datasource (plural) - op name is `datasource_readGroups` and for pages `datasource_readGroups_readGroupsAfter`


