### PR TITLE
Fix: acoount typo

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -97,7 +97,7 @@ resource "twingate_resource" "resource" {
     }
   }
 
-  // Service acoount access is specified similarly
+  // Service account access is specified similarly
   // A `for_each` block may be used like above to assign access to multiple 
   // service accounts in a single configuration block.
   access_service {

--- a/examples/resources/twingate_resource/resource.tf
+++ b/examples/resources/twingate_resource/resource.tf
@@ -82,7 +82,7 @@ resource "twingate_resource" "resource" {
     }
   }
 
-  // Service acoount access is specified similarly
+  // Service account access is specified similarly
   // A `for_each` block may be used like above to assign access to multiple 
   // service accounts in a single configuration block.
   access_service {


### PR DESCRIPTION
## Changes
- there was a typo. it says `acoount` and means `account` 
