### PR TITLE
[Workflows] Ignore issues with the backlog label

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -23,4 +23,4 @@ jobs:
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-          exempt-issue-labels: "onhold" # Exclude issues with this label
+          exempt-issue-labels: "onhold,backlog" # Exclude issues with these labels


### PR DESCRIPTION
A few planned issues were closed as stale. This change adds the `backlog` label as an exempt issue label so that we can mark any issues that are planned.