### PR TITLE
Update twingate_connector_tokens Ephemeral Resource doc with warning

### DIFF
--- a/docs/ephemeral-resources/connector_tokens.md
+++ b/docs/ephemeral-resources/connector_tokens.md
@@ -4,14 +4,16 @@ page_title: "twingate_connector_tokens Ephemeral Resource - terraform-provider-t
 subcategory: ""
 description: |-
   This resource type will generate tokens for a Connector, which are needed to successfully provision one on your network. The Connector itself has its own resource type and must be created before you can provision tokens.
-  ~> Warning: When converting existing connectors to ephemeral mode, Terraform will generate a new token during plan or apply. Until the connectors are updated with the new token, existing connectors will be unable to reconnect.
+  ~> Warning: When existing connectors are converted to ephemeral mode, Terraform generates a new token during plan or apply, preventing the connectors from reconnecting until they are updated with the new token.
+  Rather than converting existing connectors, we recommend creating new connectors with ephemeral resource tokens and deleting the old ones after migration.
 ---
 
 # twingate_connector_tokens (Ephemeral Resource)
 
 This resource type will generate tokens for a Connector, which are needed to successfully provision one on your network. The Connector itself has its own resource type and must be created before you can provision tokens.
 
-~> **Warning:** When converting existing connectors to ephemeral mode, Terraform will generate a new token during plan or apply. Until the connectors are updated with the new token, existing connectors will be unable to reconnect.
+~> **Warning:** When existing connectors are converted to ephemeral mode, Terraform generates a new token during plan or apply, preventing the connectors from reconnecting until they are updated with the new token.
+Rather than converting existing connectors, we recommend creating new connectors with ephemeral resource tokens and deleting the old ones after migration.
 
 
 

--- a/twingate/internal/provider/resource/ephemeral-connector-tokens.go
+++ b/twingate/internal/provider/resource/ephemeral-connector-tokens.go
@@ -53,7 +53,7 @@ func (r *ephemeralConnectorTokens) Configure(_ context.Context, req ephemeral.Co
 func (r *ephemeralConnectorTokens) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description:         "This resource type will generate tokens for a Connector, which are needed to successfully provision one on your network. The Connector itself has its own resource type and must be created before you can provision tokens.",
-		MarkdownDescription: "This resource type will generate tokens for a Connector, which are needed to successfully provision one on your network. The Connector itself has its own resource type and must be created before you can provision tokens.\n\n~> **Warning:** When converting existing connectors to ephemeral mode, Terraform will generate a new token during plan or apply. Until the connectors are updated with the new token, existing connectors will be unable to reconnect.",
+		MarkdownDescription: "This resource type will generate tokens for a Connector, which are needed to successfully provision one on your network. The Connector itself has its own resource type and must be created before you can provision tokens.\n\n~> **Warning:** When existing connectors are converted to ephemeral mode, Terraform generates a new token during plan or apply, preventing the connectors from reconnecting until they are updated with the new token.\nRather than converting existing connectors, we recommend creating new connectors with ephemeral resource tokens and deleting the old ones after migration.",
 		Attributes: map[string]schema.Attribute{
 			attr.ConnectorID: schema.StringAttribute{
 				Required:    true,


### PR DESCRIPTION
## Changes
- Update twingate_connector_tokens Ephemeral Resource doc with warning. There is a TF issue that only effects switching existing connectors to use use ephemeral tokens
