### PR TITLE
Update alias validation tests to expect error for empty string alias

### DIFF
--- a/twingate/internal/test/acctests/resource/resource_test.go
+++ b/twingate/internal/test/acctests/resource/resource_test.go
@@ -2146,11 +2146,9 @@ func TestAccTwingateResourceCreateWithAlias(t *testing.T) {
 				),
 			},
 			{
-				// alias attr set with emtpy string
-				Config: createResource29(terraformResourceName, remoteNetworkName, resourceName, ""),
-				Check: acctests.ComposeTestCheckFunc(
-					sdk.TestCheckResourceAttr(theResource, attr.Alias, ""),
-				),
+				// alias attr set with empty string
+				Config:      createResource29(terraformResourceName, remoteNetworkName, resourceName, ""),
+				ExpectError: regexp.MustCompile("Alias must be a[\\n\\s]+valid DNS name"),
 			},
 		},
 	})
@@ -2177,6 +2175,10 @@ func TestAccTwingateResourceUpdateWithInvalidAlias(t *testing.T) {
 			},
 			{
 				Config:      createResource29(terraformResourceName, remoteNetworkName, resourceName, "test-com"),
+				ExpectError: regexp.MustCompile("Alias must be a[\\n\\s]+valid DNS name"),
+			},
+			{
+				Config:      createResource29(terraformResourceName, remoteNetworkName, resourceName, ""),
 				ExpectError: regexp.MustCompile("Alias must be a[\\n\\s]+valid DNS name"),
 			},
 		},


### PR DESCRIPTION

## Changes
- Updated `TestAccTwingateResourceCreateWithAlias` to expect `Alias must be a valid DNS name` error when setting alias to empty string (previously asserted empty string was valid)
- Updated `TestAccTwingateResourceUpdateWithInvalidAlias` to include empty string alias as an additional invalid case