### PR TITLE
Added new cache filter option - remote_network_id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 'latest'
+          terraform_wrapper: false
       - run: make docs
       - name: git diff
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - 'README.md'
     branches:
       - main
-      - fix-merge-test-coverage
+      - feature/allow-filter-cached-resources-by-network
 
 # Ensures only 1 action runs per PR and previous is canceled on new trigger
 concurrency:

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ Optional:
 - `name_regexp` (String) The regular expression match of the name of the resource.
 - `name_suffix` (String) The name of the resource must end with the value.
 - `remote_network_id` (String) Returns only resources that are associated with the specified remote network ID.
+- `remote_network_name` (String) Returns only resources that are associated with the specified remote network name.
 - `tags` (Map of String) Returns only resources that exactly match the given tags.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,7 @@ Optional:
 - `name_prefix` (String) The name of the resource must start with the value.
 - `name_regexp` (String) The regular expression match of the name of the resource.
 - `name_suffix` (String) The name of the resource must end with the value.
+- `remote_network_id` (String) Returns only resources that are associated with the specified remote network ID.
 - `tags` (Map of String) Returns only resources that exactly match the given tags.
 
 

--- a/twingate/internal/attr/common.go
+++ b/twingate/internal/attr/common.go
@@ -1,11 +1,12 @@
 package attr
 
 const (
-	ID              = "id"
-	Name            = "name"
-	RemoteNetworkID = "remote_network_id"
-	Type            = "type"
-	IsActive        = "is_active"
+	ID                = "id"
+	Name              = "name"
+	RemoteNetworkID   = "remote_network_id"
+	RemoteNetworkName = "remote_network_name"
+	Type              = "type"
+	IsActive          = "is_active"
 
 	FilterByRegexp   = "_regexp"
 	FilterByContains = "_contains"

--- a/twingate/internal/client/cache.go
+++ b/twingate/internal/client/cache.go
@@ -33,10 +33,22 @@ type ReadClient interface {
 
 	ReadFullResourcesByName(ctx context.Context, filter *model.ResourcesFilter) ([]*model.Resource, error)
 	ReadFullGroupsByName(ctx context.Context, filter *model.GroupsFilter) ([]*model.Group, error)
+
+	ReadRemoteNetworkByName(ctx context.Context, remoteNetworkName string) (*model.RemoteNetwork, error)
 }
 
-func (c *clientCache) setClient(client ReadClient, opts CacheOptions) {
+func (c *clientCache) setClient(ctx context.Context, client ReadClient, opts CacheOptions) {
 	c.once.Do(func() {
+		if opts.ResourceEnabled && opts.ResourcesFilter != nil &&
+			opts.ResourcesFilter.RemoteNetworkName != nil && *opts.ResourcesFilter.RemoteNetworkName != "" {
+			remoteNetwork, err := client.ReadRemoteNetworkByName(WithCallerCtx(ctx, cacheKey), *opts.ResourcesFilter.RemoteNetworkName)
+			if err != nil {
+				log.Printf("[TWINGATE_LOG] [ERR] cache init failed to fetch remote network by name - %s: %s", *opts.ResourcesFilter.RemoteNetworkName, err.Error())
+			} else if remoteNetwork != nil {
+				opts.ResourcesFilter.RemoteNetworkID = &remoteNetwork.ID
+			}
+		}
+
 		c.handlers = map[string]resourceHandler{
 			reflect.TypeFor[*model.Resource]().String(): &handler[*model.Resource, *model.ResourcesFilter]{
 				enabled:         opts.ResourceEnabled,

--- a/twingate/internal/client/cache.go
+++ b/twingate/internal/client/cache.go
@@ -294,7 +294,7 @@ func isCacheReady[T any]() bool {
 	)
 
 	handle(res, func(handler resourceHandler) {
-		ready = handler.isEnabled() && !handler.isFilterSet()
+		ready = handler.isEnabled() && handler.isFilterSet()
 	})
 
 	return ready

--- a/twingate/internal/client/cache_test.go
+++ b/twingate/internal/client/cache_test.go
@@ -17,6 +17,10 @@ var skipCache = CacheOptions{}
 type mockClient struct {
 }
 
+func (m mockClient) ReadRemoteNetworkByName(ctx context.Context, remoteNetworkName string) (*model.RemoteNetwork, error) {
+	return &model.RemoteNetwork{}, nil
+}
+
 func (m mockClient) ReadFullResourcesByName(ctx context.Context, filter *model.ResourcesFilter) ([]*model.Resource, error) {
 	return []*model.Resource{}, nil
 }
@@ -35,7 +39,7 @@ func (m mockClient) ReadFullGroups(ctx context.Context) ([]*model.Group, error) 
 
 func TestClientCache_SetClient(t *testing.T) {
 	cache := &clientCache{}
-	cache.setClient(&mockClient{}, skipCache)
+	cache.setClient(t.Context(), &mockClient{}, skipCache)
 
 	assert.NotNil(t, cache.handlers)
 	assert.Contains(t, cache.handlers, reflect.TypeOf(&model.Resource{}).String())

--- a/twingate/internal/client/client.go
+++ b/twingate/internal/client/client.go
@@ -183,7 +183,7 @@ func customRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 	return true, nil
 }
 
-func NewClient(url string, apiToken string, network string, httpTimeout time.Duration, httpRetryMax int, agent, version string, opts CacheOptions) *Client {
+func NewClient(ctx context.Context, url string, apiToken string, network string, httpTimeout time.Duration, httpRetryMax int, agent, version string, opts CacheOptions) *Client {
 	correlationID, _ := uuid.GenerateUUID()
 
 	sURL := newServerURL(network, url)
@@ -222,7 +222,7 @@ func NewClient(url string, apiToken string, network string, httpTimeout time.Dur
 	log.Printf("[INFO] Using Server URL %s", sURL.newGraphqlServerURL())
 
 	if opts.GroupsEnabled || opts.ResourceEnabled {
-		cache.setClient(&client, opts)
+		cache.setClient(ctx, &client, opts)
 	}
 
 	return &client

--- a/twingate/internal/client/client_test.go
+++ b/twingate/internal/client/client_test.go
@@ -18,15 +18,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestClient() *Client {
-	return NewClient(
+func newTestClient(ctx context.Context) *Client {
+	return NewClient(ctx,
 		"twindev.com", "xxxx", "test",
 		time.Duration(1)*time.Second, 0, DefaultAgent, "test", skipCache,
 	)
 }
 
 func TestNewClientPayloadMarshalError(t *testing.T) {
-	c := newTestClient()
+	c := newTestClient(t.Context())
 	_, err := c.post(context.TODO(), "/hello", make(chan int), nil)
 
 	assert.ErrorContains(t, err, "json")
@@ -36,14 +36,14 @@ func TestNewClientCancelledContextError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	cancel()
 
-	c := newTestClient()
+	c := newTestClient(t.Context())
 	_, err := c.post(ctx, "/hello", "hello", nil)
 
 	assert.ErrorContains(t, err, "can't execute http request")
 }
 
 func TestNewClientNilContextError(t *testing.T) {
-	c := newTestClient()
+	c := newTestClient(t.Context())
 	_, err := c.post(nil, "/hello", "hello", nil)
 
 	assert.ErrorContains(t, err, "net/http: nil Context")
@@ -60,7 +60,7 @@ func (d *dummyFailingReadCloser) Close() error {
 }
 
 func TestClientFailedReadBody(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(t.Context())
 	httpmock.ActivateNonDefault(client.HTTPClient)
 	defer httpmock.DeactivateAndReset()
 
@@ -81,7 +81,7 @@ func TestClientAPITokenNotSet(t *testing.T) {
 	os.Setenv(EnvAPIToken, "")
 	defer os.Setenv(EnvAPIToken, apiToken)
 
-	client := NewClient(
+	client := NewClient(t.Context(),
 		"twindev.com", "", "test",
 		time.Duration(1)*time.Second, 0, DefaultAgent, "test", skipCache,
 	)
@@ -97,7 +97,7 @@ func TestClientAPITokenNotSet(t *testing.T) {
 }
 
 func TestClientInvalidServerAddress(t *testing.T) {
-	client := NewClient(
+	client := NewClient(t.Context(),
 		"beamreach.twingate.com", "XXXXX", "beamreach",
 		time.Duration(10)*time.Second, 3, DefaultAgent, "test", skipCache,
 	)

--- a/twingate/internal/client/kubernetes-resource_test.go
+++ b/twingate/internal/client/kubernetes-resource_test.go
@@ -52,7 +52,7 @@ func TestReadKubernetesResources(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			client := newTestClient()
+			client := newTestClient(t.Context())
 			httpmock.ActivateNonDefault(client.HTTPClient)
 			defer httpmock.DeactivateAndReset()
 

--- a/twingate/internal/client/query/query_test.go
+++ b/twingate/internal/client/query/query_test.go
@@ -2688,7 +2688,7 @@ func TestResourceFilter(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result := NewResourceFilterInput(c.inputName, c.inputFilter, nil)
+			result := NewResourceFilterInput(c.inputName, c.inputFilter, nil, nil)
 
 			assert.Equal(t, c.expectedFilter, result.Name)
 		})
@@ -2735,7 +2735,7 @@ func TestResourceFilterTags(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result := NewResourceFilterInput("", "", c.tags)
+			result := NewResourceFilterInput("", "", c.tags, nil)
 
 			if c.expectedFilter == nil {
 				assert.Nil(t, result.Tags)
@@ -2746,6 +2746,35 @@ func TestResourceFilterTags(t *testing.T) {
 
 				assert.EqualValues(t, c.expectedFilter, result.Tags)
 			}
+		})
+	}
+}
+
+func TestResourceFilterRemoteNetworkId(t *testing.T) {
+	cases := []struct {
+		name            string
+		remoteNetworkId *string
+		expectedFilter  *RemoteNetworkIdFilterOperationInput
+	}{
+		{
+			name:            "With remoteNetworkId",
+			remoteNetworkId: optionalString("network-id-1"),
+			expectedFilter: &RemoteNetworkIdFilterOperationInput{
+				Eq: optionalString("network-id-1"),
+			},
+		},
+		{
+			name:            "Nil remoteNetworkId",
+			remoteNetworkId: nil,
+			expectedFilter:  nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := NewResourceFilterInput("", "", nil, c.remoteNetworkId)
+
+			assert.Equal(t, c.expectedFilter, result.RemoteNetworkID)
 		})
 	}
 }

--- a/twingate/internal/client/query/resources-by-name-read.go
+++ b/twingate/internal/client/query/resources-by-name-read.go
@@ -9,14 +9,16 @@ func (q ReadResourcesByName) IsEmpty() bool {
 }
 
 type ResourceFilterInput struct {
-	Name *StringFilterOperationInput `json:"name"`
-	Tags *TagsFilterOperatorInput    `json:"tags"`
+	Name            *StringFilterOperationInput          `json:"name"`
+	Tags            *TagsFilterOperatorInput             `json:"tags"`
+	RemoteNetworkID *RemoteNetworkIdFilterOperationInput `json:"remoteNetworkId"`
 }
 
-func NewResourceFilterInput(name, filter string, tags map[string]string) *ResourceFilterInput {
+func NewResourceFilterInput(name, filter string, tags map[string]string, remoteNetworkId *string) *ResourceFilterInput {
 	return &ResourceFilterInput{
-		Name: NewStringFilterOperationInput(name, filter),
-		Tags: NewTagsFilterOperatorInput(tags),
+		Name:            NewStringFilterOperationInput(name, filter),
+		Tags:            NewTagsFilterOperatorInput(tags),
+		RemoteNetworkID: NewRemoteNetworkIdFilterOperationInput(remoteNetworkId),
 	}
 }
 
@@ -41,6 +43,16 @@ func NewTagsFilterOperatorInput(tags map[string]string) *TagsFilterOperatorInput
 	return filter
 }
 
+func NewRemoteNetworkIdFilterOperationInput(remoteNetworkId *string) *RemoteNetworkIdFilterOperationInput {
+	if remoteNetworkId == nil {
+		return nil
+	}
+
+	return &RemoteNetworkIdFilterOperationInput{
+		Eq: remoteNetworkId,
+	}
+}
+
 type TagsFilterOperatorInput struct {
 	And []TagKeyValueFilterInput `json:"and"`
 }
@@ -52,4 +64,9 @@ type TagKeyValueFilterInput struct {
 
 type TagValueFilterInput struct {
 	Eq *string `json:"eq"`
+}
+
+type RemoteNetworkIdFilterOperationInput struct {
+	Eq *string  `json:"eq"`
+	In []string `json:"in"`
 }

--- a/twingate/internal/client/resource.go
+++ b/twingate/internal/client/resource.go
@@ -322,7 +322,7 @@ func (client *Client) ReadFullResourcesByName(ctx context.Context, filter *model
 	opr := resourceResource.read().withCustomName("readFullResourcesByName")
 
 	variables := newVars(
-		gqlNullable(query.NewResourceFilterInput(filter.GetName(), filter.GetFilterBy(), filter.GetTags()), "filter"),
+		gqlNullable(query.NewResourceFilterInput(filter.GetName(), filter.GetFilterBy(), filter.GetTags(), filter.RemoteNetworkID), "filter"),
 		cursor(query.CursorAccess),
 		cursor(query.CursorResources),
 		pageLimit(extendedPageLimit),
@@ -490,10 +490,12 @@ func (client *Client) ReadResourcesByName(ctx context.Context, filter *model.Res
 		}
 
 		log.Println("[DEBUG] ReadResourcesByName: no matched resource in cache: fallback to query API")
+	} else {
+		log.Println("[DEBUG] ReadResourcesByName: cache is not ready: fallback to query API")
 	}
 
 	variables := newVars(
-		gqlNullable(query.NewResourceFilterInput(filter.GetName(), filter.GetFilterBy(), filter.GetTags()), "filter"),
+		gqlNullable(query.NewResourceFilterInput(filter.GetName(), filter.GetFilterBy(), filter.GetTags(), filter.RemoteNetworkID), "filter"),
 		cursor(query.CursorResources),
 		pageLimit(client.pageLimit),
 	)

--- a/twingate/internal/client/ssh-certificate-authority_test.go
+++ b/twingate/internal/client/ssh-certificate-authority_test.go
@@ -51,7 +51,7 @@ func TestReadSSHCertificateAuthorities(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			client := newTestClient()
+			client := newTestClient(t.Context())
 			httpmock.ActivateNonDefault(client.HTTPClient)
 			defer httpmock.DeactivateAndReset()
 

--- a/twingate/internal/client/ssh-resource_test.go
+++ b/twingate/internal/client/ssh-resource_test.go
@@ -52,7 +52,7 @@ func TestReadSSHResources(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			client := newTestClient()
+			client := newTestClient(t.Context())
 			httpmock.ActivateNonDefault(client.HTTPClient)
 			defer httpmock.DeactivateAndReset()
 

--- a/twingate/internal/client/x509-certificate-authority_test.go
+++ b/twingate/internal/client/x509-certificate-authority_test.go
@@ -51,7 +51,7 @@ func TestReadX509CertificateAuthorities(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			client := newTestClient()
+			client := newTestClient(t.Context())
 			httpmock.ActivateNonDefault(client.HTTPClient)
 			defer httpmock.DeactivateAndReset()
 

--- a/twingate/internal/model/group.go
+++ b/twingate/internal/model/group.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
@@ -142,4 +143,39 @@ func (f *GroupsFilter) HasNotSupportedFilters() bool {
 func (f *GroupsFilter) GetTags() map[string]string {
 	// not supported
 	return nil
+}
+
+func (f *GroupsFilter) GetRemoteNetworkID() *string {
+	return nil
+}
+
+func (f *GroupsFilter) String() string {
+	if f == nil {
+		return "GroupsFilter{<nil>}"
+	}
+
+	var parts []string
+
+	if f.HasName() {
+		match := f.NameFilter
+		if match == "" {
+			match = "exact"
+		}
+
+		parts = append(parts, fmt.Sprintf("Name(%s)=%q", match, f.GetName()))
+	}
+
+	if len(f.Types) > 0 {
+		parts = append(parts, fmt.Sprintf("Types=%v", f.Types))
+	}
+
+	if f.IsActive != nil {
+		parts = append(parts, fmt.Sprintf("IsActive=%v", *f.IsActive))
+	}
+
+	if len(parts) == 0 {
+		return "GroupsFilter{}"
+	}
+
+	return "GroupsFilter{" + strings.Join(parts, ", ") + "}"
 }

--- a/twingate/internal/model/resource.go
+++ b/twingate/internal/model/resource.go
@@ -415,10 +415,11 @@ func (p *Protocol) ToTerraform() []any {
 }
 
 type ResourcesFilter struct {
-	Name            *string
-	NameFilter      string
-	Tags            map[string]string
-	RemoteNetworkID *string
+	Name              *string
+	NameFilter        string
+	Tags              map[string]string
+	RemoteNetworkID   *string
+	RemoteNetworkName *string
 }
 
 func (f *ResourcesFilter) HasName() bool {
@@ -481,6 +482,10 @@ func (f *ResourcesFilter) String() string {
 
 	if len(f.Tags) > 0 {
 		parts = append(parts, fmt.Sprintf("Tags=%v", f.Tags))
+	}
+
+	if f.RemoteNetworkName != nil && *f.RemoteNetworkName != "" {
+		parts = append(parts, fmt.Sprintf("RemoteNetworkName=%q", *f.RemoteNetworkName))
 	}
 
 	if f.RemoteNetworkID != nil && *f.RemoteNetworkID != "" {

--- a/twingate/internal/model/resource.go
+++ b/twingate/internal/model/resource.go
@@ -204,6 +204,9 @@ type ResourceFilter interface {
 	GetTypes() []string
 	GetIsActive() *bool
 	GetTags() map[string]string
+	GetRemoteNetworkID() *string
+
+	String() string
 }
 
 func (r Resource) Match(filter ResourceFilter) bool {
@@ -258,6 +261,11 @@ func (r Resource) Match(filter ResourceFilter) bool {
 				return false
 			}
 		}
+	}
+
+	// filter by remote network id
+	if filter.GetRemoteNetworkID() != nil && *filter.GetRemoteNetworkID() != r.RemoteNetworkID {
+		return false
 	}
 
 	return true
@@ -407,9 +415,10 @@ func (p *Protocol) ToTerraform() []any {
 }
 
 type ResourcesFilter struct {
-	Name       *string
-	NameFilter string
-	Tags       map[string]string
+	Name            *string
+	NameFilter      string
+	Tags            map[string]string
+	RemoteNetworkID *string
 }
 
 func (f *ResourcesFilter) HasName() bool {
@@ -448,4 +457,39 @@ func (f *ResourcesFilter) HasNotSupportedFilters() bool {
 
 func (f *ResourcesFilter) GetTags() map[string]string {
 	return f.Tags
+}
+
+func (f *ResourcesFilter) GetRemoteNetworkID() *string {
+	return f.RemoteNetworkID
+}
+
+func (f *ResourcesFilter) String() string {
+	if f == nil {
+		return "ResourcesFilter{<nil>}"
+	}
+
+	var parts []string
+
+	if f.HasName() {
+		match := f.NameFilter
+		if match == "" {
+			match = "exact"
+		}
+
+		parts = append(parts, fmt.Sprintf("Name(%s)=%q", match, f.GetName()))
+	}
+
+	if len(f.Tags) > 0 {
+		parts = append(parts, fmt.Sprintf("Tags=%v", f.Tags))
+	}
+
+	if f.RemoteNetworkID != nil && *f.RemoteNetworkID != "" {
+		parts = append(parts, fmt.Sprintf("RemoteNetworkID=%q", *f.RemoteNetworkID))
+	}
+
+	if len(parts) == 0 {
+		return "ResourcesFilter{}"
+	}
+
+	return "ResourcesFilter{" + strings.Join(parts, ", ") + "}"
 }

--- a/twingate/internal/test/client.go
+++ b/twingate/internal/test/client.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -27,7 +28,7 @@ func getHTTPTimeout(key string, duration time.Duration) time.Duration {
 }
 
 func TwingateClient() (*client.Client, error) {
-	return client.NewClient(
+	return client.NewClient(context.Background(),
 			os.Getenv(twingate.EnvURL),
 			os.Getenv(twingate.EnvAPIToken),
 			os.Getenv(twingate.EnvNetwork),

--- a/twingate/internal/test/client/client_test.go
+++ b/twingate/internal/test/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sync"
@@ -12,7 +13,7 @@ import (
 
 func newHTTPMockClient() *client.Client {
 
-	c := client.NewClient("twindev.com", "xxxx", "test",
+	c := client.NewClient(context.Background(), "twindev.com", "xxxx", "test",
 		time.Duration(1)*time.Second, 2, client.DefaultAgent, "test", client.CacheOptions{})
 	httpmock.ActivateNonDefault(c.HTTPClient)
 

--- a/twingate/internal/test/sweepers/sweeper_test.go
+++ b/twingate/internal/test/sweepers/sweeper_test.go
@@ -44,7 +44,7 @@ func sharedClient(tenant string) (*client.Client, error) {
 		return nil, fmt.Errorf("must provide environment variable %s", twingate.EnvURL)
 	}
 
-	return client.NewClient(
+	return client.NewClient(context.Background(),
 			os.Getenv(twingate.EnvURL),
 			os.Getenv(twingate.EnvAPIToken),
 			os.Getenv(twingate.EnvNetwork),

--- a/twingate/provider.go
+++ b/twingate/provider.go
@@ -150,6 +150,16 @@ func (t Twingate) Schema(ctx context.Context, request provider.SchemaRequest, re
 							attr.RemoteNetworkID: schema.StringAttribute{
 								Optional:    true,
 								Description: "Returns only resources that are associated with the specified remote network ID.",
+								Validators: []validator.String{
+									stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName(attr.RemoteNetworkName)),
+								},
+							},
+							attr.RemoteNetworkName: schema.StringAttribute{
+								Optional:    true,
+								Description: "Returns only resources that are associated with the specified remote network name.",
+								Validators: []validator.String{
+									stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName(attr.RemoteNetworkID)),
+								},
 							},
 						},
 					},
@@ -264,7 +274,9 @@ func (t Twingate) Configure(ctx context.Context, request provider.ConfigureReque
 		return
 	}
 
-	client := client.NewClient(url,
+	client := client.NewClient(
+		ctx,
+		url,
 		apiToken,
 		network,
 		time.Duration(httpTimeout)*time.Second,
@@ -361,11 +373,19 @@ func parseResourcesFilter(config types.Object) (*model.ResourcesFilter, error) {
 		remoteNetworkIDVal = nil
 	}
 
+	remoteNetworkName := attrs[attr.RemoteNetworkName].(types.String)
+
+	remoteNetworkNameVal := remoteNetworkName.ValueStringPointer()
+	if remoteNetworkNameVal != nil && *remoteNetworkNameVal == "" {
+		remoteNetworkNameVal = nil
+	}
+
 	return &model.ResourcesFilter{
-		Name:            &value,
-		NameFilter:      filter,
-		Tags:            twingateDatasource.GetTags(tags),
-		RemoteNetworkID: remoteNetworkIDVal,
+		Name:              &value,
+		NameFilter:        filter,
+		Tags:              twingateDatasource.GetTags(tags),
+		RemoteNetworkID:   remoteNetworkIDVal,
+		RemoteNetworkName: remoteNetworkNameVal,
 	}, nil
 }
 

--- a/twingate/provider.go
+++ b/twingate/provider.go
@@ -147,6 +147,10 @@ func (t Twingate) Schema(ctx context.Context, request provider.SchemaRequest, re
 								Optional:    true,
 								Description: "Returns only resources that exactly match the given tags.",
 							},
+							attr.RemoteNetworkID: schema.StringAttribute{
+								Optional:    true,
+								Description: "Returns only resources that are associated with the specified remote network ID.",
+							},
 						},
 					},
 					attr.GroupsEnabled: schema.BoolAttribute{
@@ -350,10 +354,18 @@ func parseResourcesFilter(config types.Object) (*model.ResourcesFilter, error) {
 
 	tags := attrs[attr.Tags].(types.Map)
 
+	remoteNetworkID := attrs[attr.RemoteNetworkID].(types.String)
+
+	remoteNetworkIDVal := remoteNetworkID.ValueStringPointer()
+	if remoteNetworkIDVal != nil && *remoteNetworkIDVal == "" {
+		remoteNetworkIDVal = nil
+	}
+
 	return &model.ResourcesFilter{
-		Name:       &value,
-		NameFilter: filter,
-		Tags:       twingateDatasource.GetTags(tags),
+		Name:            &value,
+		NameFilter:      filter,
+		Tags:            twingateDatasource.GetTags(tags),
+		RemoteNetworkID: remoteNetworkIDVal,
 	}, nil
 }
 


### PR DESCRIPTION
Resolves https://github.com/Twingate/terraform-provider-twingate/issues/845

Tests passes: https://github.com/vmanilo/terraform-provider-twingate/actions/runs/24743598699

## Changes
- fixed `isCacheReady`
- added new filter option `cache.resources_filter.remote_network_id`
- added new filter option `cache.resources_filter.remote_network_name`

## Example

```terraform
provider "twingate" {
  cache = {
    groups_enabled = false

    resource_enabled = true
    resources_filter = {
      name_contains = "example"
      #remote_network_id = "UmVtb3RlTmV0d29yazo2MTU2NzE4"
      remote_network_name = "aws-network"
    }
  }
}
``` 
