### PR TITLE
Fix Update twingate_sync_to_s3 datasource oidc url

### DIFF
--- a/docs/data-sources/sync_to_s3.md
+++ b/docs/data-sources/sync_to_s3.md
@@ -39,5 +39,5 @@ output "oidc_prefix" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `oidc_prefix` (String) The IAM Identity Provider prefix (return only if type "oidc"). Example: tenant.twingate.com/oidc/v2
-- `oidc_url` (String) The IAM Identity Provider URL (return only if type "oidc"). Example: https://tenant.twingate.com/oidc/v2
+- `oidc_prefix` (String) The IAM Identity Provider prefix (return only if type "oidc"). Example: tenant.twingate.com/oidc
+- `oidc_url` (String) The IAM Identity Provider URL (return only if type "oidc"). Example: https://tenant.twingate.com/oidc

--- a/twingate/internal/provider/datasource/sync-to-s3.go
+++ b/twingate/internal/provider/datasource/sync-to-s3.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	oidcAPI     = "/oidc/v2"
+	oidcAPI     = "/oidc"
 	httpsPrefix = "https://"
 	defaultType = model.SyncToS3TypeOIDC
 )

--- a/twingate/internal/test/acctests/datasource/sync-to-s3_test.go
+++ b/twingate/internal/test/acctests/datasource/sync-to-s3_test.go
@@ -44,8 +44,8 @@ func TestAccDatasourceTwingateSyncToS3_oidc(t *testing.T) {
 				Check: acctests.ComposeTestCheckFunc(
 					sdk.TestCheckResourceAttrSet(theDatasource, attr.ID),
 					sdk.TestCheckResourceAttr(theDatasource, attr.Type, model.SyncToS3TypeOIDC),
-					sdk.TestMatchResourceAttr(theDatasource, attr.OidcURL, regexp.MustCompile(`^https://.+/oidc/v2$`)),
-					sdk.TestMatchResourceAttr(theDatasource, attr.OidcPrefix, regexp.MustCompile(`^[^/]+/oidc/v2$`)),
+					sdk.TestMatchResourceAttr(theDatasource, attr.OidcURL, regexp.MustCompile(`^https://.+/oidc$`)),
+					sdk.TestMatchResourceAttr(theDatasource, attr.OidcPrefix, regexp.MustCompile(`^[^/]+/oidc$`)),
 				),
 			},
 		},


### PR DESCRIPTION


Resolves [`<github issue>`](https://github.com/Twingate/terraform-provider-twingate/issues/876)

## Changes
- Update the oidc_url and oidc_prefix to be /oidc instead of /oidc/v2


## Tests

Changes to Outputs:
  ~ oidc_prefix = "bob.stg.opstg.com/oidc/v2" -> "bob.stg.opstg.com/oidc"
  ~ oidc_url    = "https://bob.stg.opstg.com/oidc/v2" -> "https://bob.stg.opstg.com/oidc"
  
  

