### PR TITLE
Replace gateway config `upstreams` with an `enabled` flag

### DIFF
--- a/docs/resources/gateway_config.md
+++ b/docs/resources/gateway_config.md
@@ -77,6 +77,8 @@ resource "twingate_gateway_config" "config" {
   }
 
   ssh = {
+    enabled = true
+
     # SSH gateway process settings. All fields are optional with built-in defaults.
     gateway = {
       username      = "gateway"  # OS user the gateway process runs as. Default: "gateway".
@@ -122,11 +124,10 @@ resource "twingate_gateway_config" "config" {
       # private_key_file = "/etc/gateway/ssh_ca_key"
     }
 
-    resources = [twingate_ssh_resource.ssh_server, twingate_ssh_resource.ssh_server_2]
   }
 
   kubernetes = {
-    resources = [twingate_kubernetes_resource.prod_cluster]
+    enabled = true
   }
 }
 
@@ -141,10 +142,10 @@ resource "local_sensitive_file" "config" {
 
 ### Optional
 
-- `kubernetes` (Attributes) Kubernetes configuration block containing resource settings. (see [below for nested schema](#nestedatt--kubernetes))
+- `kubernetes` (Attributes) Kubernetes configuration block. (see [below for nested schema](#nestedatt--kubernetes))
 - `metrics_port` (Number) Gateway metrics port. Default: 9090.
 - `port` (Number) Gateway listen port. Default: 8443.
-- `ssh` (Attributes) SSH configuration block containing gateway, CA, and resource settings. (see [below for nested schema](#nestedatt--ssh))
+- `ssh` (Attributes) SSH configuration block containing gateway and CA settings. (see [below for nested schema](#nestedatt--ssh))
 - `tls` (Attributes) TLS configuration for the gateway. (see [below for nested schema](#nestedatt--tls))
 
 ### Read-Only
@@ -157,17 +158,7 @@ resource "local_sensitive_file" "config" {
 
 Optional:
 
-- `resources` (List of Object) List of Kubernetes resources. Accepts full twingate_kubernetes_resource references. (see [below for nested schema](#nestedatt--kubernetes--resources))
-
-<a id="nestedatt--kubernetes--resources"></a>
-### Nested Schema for `kubernetes.resources`
-
-Optional:
-
-- `address` (String)
-- `in_cluster` (Boolean)
-- `name` (String)
-
+- `enabled` (Boolean) Whether Kubernetes is enabled on the gateway. Default: false.
 
 
 <a id="nestedatt--ssh"></a>
@@ -176,8 +167,8 @@ Optional:
 Optional:
 
 - `ca` (Attributes) SSH CA configuration. Specify either vault.address or private_key_file, not both. (see [below for nested schema](#nestedatt--ssh--ca))
+- `enabled` (Boolean) Whether the SSH protocol is enabled on the gateway. Default: false.
 - `gateway` (Attributes) SSH gateway settings. All fields are optional and fall back to built-in defaults. (see [below for nested schema](#nestedatt--ssh--gateway))
-- `resources` (List of Object) List of SSH resources. Accepts full twingate_ssh_resource references. (see [below for nested schema](#nestedatt--ssh--resources))
 
 <a id="nestedatt--ssh--ca"></a>
 ### Nested Schema for `ssh.ca`
@@ -229,16 +220,6 @@ Optional:
 - `key_type` (String) SSH key type. Default: "ed25519".
 - `user_cert_ttl` (String) User certificate TTL. Default: "5m".
 - `username` (String) SSH gateway username. Default: "gateway".
-
-
-<a id="nestedatt--ssh--resources"></a>
-### Nested Schema for `ssh.resources`
-
-Optional:
-
-- `address` (String)
-- `name` (String)
-- `username` (String)
 
 
 

--- a/examples/aws-gateway-ssh-self-signed/gateway.tf
+++ b/examples/aws-gateway-ssh-self-signed/gateway.tf
@@ -21,12 +21,10 @@ resource "twingate_gateway_config" "config" {
   }
 
   ssh = {
+    enabled = true
+
     gateway = { username = "gateway" }
     ca      = { private_key_file = "/etc/gateway/ssh-ca.key" }
-
-    resources = [
-      twingate_ssh_resource.ssh_server,
-    ]
   }
 }
 

--- a/examples/do-gateway-ssh-self-signed/gateway.tf
+++ b/examples/do-gateway-ssh-self-signed/gateway.tf
@@ -20,12 +20,10 @@ resource "twingate_gateway_config" "config" {
   }
 
   ssh = {
+    enabled = true
+
     gateway = { username = "gateway" }
     ca      = { private_key_file = "/etc/gateway/ssh-ca.key" }
-
-    resources = [
-      twingate_ssh_resource.ssh_server,
-    ]
   }
 }
 

--- a/examples/gce-gateway-ssh-self-signed/gateway.tf
+++ b/examples/gce-gateway-ssh-self-signed/gateway.tf
@@ -24,6 +24,8 @@ resource "twingate_gateway_config" "config" {
   }
 
   ssh = {
+    enabled = true
+
     gateway = {
       username = "gateway"
     }
@@ -31,8 +33,6 @@ resource "twingate_gateway_config" "config" {
     ca = {
       private_key_file = "/etc/gateway/ssh-ca.key"
     }
-
-    resources = [twingate_ssh_resource.ssh_server]
   }
 }
 

--- a/examples/gce-gateway-ssh-vault/gateway.tf
+++ b/examples/gce-gateway-ssh-vault/gateway.tf
@@ -62,6 +62,8 @@ resource "twingate_gateway_config" "config" {
   }
 
   ssh = {
+    enabled = true
+
     gateway = {
       username = "gateway"
     }
@@ -83,7 +85,5 @@ resource "twingate_gateway_config" "config" {
         }
       }
     }
-
-    resources = [twingate_ssh_resource.ssh_server]
   }
 }

--- a/examples/resources/twingate_gateway_config/resource.tf
+++ b/examples/resources/twingate_gateway_config/resource.tf
@@ -62,6 +62,8 @@ resource "twingate_gateway_config" "config" {
   }
 
   ssh = {
+    enabled = true
+
     # SSH gateway process settings. All fields are optional with built-in defaults.
     gateway = {
       username      = "gateway"  # OS user the gateway process runs as. Default: "gateway".
@@ -107,11 +109,10 @@ resource "twingate_gateway_config" "config" {
       # private_key_file = "/etc/gateway/ssh_ca_key"
     }
 
-    resources = [twingate_ssh_resource.ssh_server, twingate_ssh_resource.ssh_server_2]
   }
 
   kubernetes = {
-    resources = [twingate_kubernetes_resource.prod_cluster]
+    enabled = true
   }
 }
 

--- a/twingate/internal/attr/gateway-config.go
+++ b/twingate/internal/attr/gateway-config.go
@@ -5,6 +5,7 @@ const (
 	PrivateKeyFile      = "private_key_file"
 	Kubernetes          = "kubernetes"
 	Content             = "content"
+	Enabled             = "enabled"
 	SSH                 = "ssh"
 	Gateway             = "gateway"
 	CA                  = "ca"

--- a/twingate/internal/provider/resource/gateway-config.go
+++ b/twingate/internal/provider/resource/gateway-config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -51,9 +52,7 @@ const (
 
 var (
 	ErrExtractSSH                       = errors.New("failed to extract ssh")
-	ErrExtractSSHResources              = errors.New("failed to extract ssh.resources")
 	ErrExtractKubernetes                = errors.New("failed to extract kubernetes")
-	ErrExtractKubernetesResources       = errors.New("failed to extract kubernetes.resources")
 	ErrExtractSSHGateway                = errors.New("failed to extract ssh.gateway")
 	ErrExtractTLS                       = errors.New("failed to extract tls")
 	ErrExtractSSHCA                     = errors.New("failed to extract ssh.ca")
@@ -90,29 +89,13 @@ type gatewayConfigModel struct {
 }
 
 type kubernetesModel struct {
-	Resources types.List `tfsdk:"resources"`
-}
-
-func (m *kubernetesModel) IsEmptyResources() bool {
-	if m == nil {
-		return true
-	}
-
-	return m.Resources.IsNull() || m.Resources.IsUnknown() || len(m.Resources.Elements()) == 0
+	Enabled types.Bool `tfsdk:"enabled"`
 }
 
 type sshModel struct {
-	Gateway   types.Object `tfsdk:"gateway"`
-	CA        types.Object `tfsdk:"ca"`
-	Resources types.List   `tfsdk:"resources"`
-}
-
-func (m *sshModel) IsEmptyResources() bool {
-	if m == nil {
-		return true
-	}
-
-	return m.Resources.IsNull() || m.Resources.IsUnknown() || len(m.Resources.Elements()) == 0
+	Enabled types.Bool   `tfsdk:"enabled"`
+	Gateway types.Object `tfsdk:"gateway"`
+	CA      types.Object `tfsdk:"ca"`
 }
 
 type tlsModel struct {
@@ -193,18 +176,6 @@ type gcpModel struct {
 	ServiceAccountEmail types.String `tfsdk:"service_account_email"`
 }
 
-type sshResourceRef struct {
-	Name     types.String `tfsdk:"name"`
-	Address  types.String `tfsdk:"address"`
-	Username types.String `tfsdk:"username"`
-}
-
-type kubernetesResourceRef struct {
-	Name      types.String `tfsdk:"name"`
-	Address   types.String `tfsdk:"address"`
-	InCluster types.Bool   `tfsdk:"in_cluster"`
-}
-
 type gatewayConfigData struct {
 	TwingateNetwork string
 	TwingateHost    string
@@ -221,13 +192,13 @@ type tlsData struct {
 }
 
 type sshData struct {
-	Gateway   sshGatewayData
-	CA        sshCAData
-	Resources []sshResourceData
+	Enabled bool
+	Gateway sshGatewayData
+	CA      sshCAData
 }
 
 type kubernetesData struct {
-	Resources []kubernetesResourceData
+	Enabled bool
 }
 
 type sshGatewayData struct {
@@ -260,18 +231,6 @@ type gcpData struct {
 	Type                string
 	Mount               string
 	ServiceAccountEmail string
-}
-
-type sshResourceData struct {
-	Name     string
-	Address  string
-	Username string
-}
-
-type kubernetesResourceData struct {
-	Name      string
-	Address   string
-	InCluster bool
 }
 
 func tlsAttrTypes() map[string]fwattr.Type {
@@ -323,37 +282,17 @@ func sshCAAttrTypes() map[string]fwattr.Type {
 	}
 }
 
-func sshResourceElemType() fwattr.Type {
-	return types.ObjectType{
-		AttrTypes: map[string]fwattr.Type{
-			attr.Name:     types.StringType,
-			attr.Address:  types.StringType,
-			attr.Username: types.StringType,
-		},
-	}
-}
-
-func kubernetesResourceElemType() fwattr.Type {
-	return types.ObjectType{
-		AttrTypes: map[string]fwattr.Type{
-			attr.Name:      types.StringType,
-			attr.Address:   types.StringType,
-			attr.InCluster: types.BoolType,
-		},
-	}
-}
-
 func kubernetesAttrTypes() map[string]fwattr.Type {
 	return map[string]fwattr.Type{
-		attr.Resources: types.ListType{ElemType: kubernetesResourceElemType()},
+		attr.Enabled: types.BoolType,
 	}
 }
 
 func sshAttrTypes() map[string]fwattr.Type {
 	return map[string]fwattr.Type{
-		attr.Gateway:   types.ObjectType{AttrTypes: sshGatewayAttrTypes()},
-		attr.CA:        types.ObjectType{AttrTypes: sshCAAttrTypes()},
-		attr.Resources: types.ListType{ElemType: sshResourceElemType()},
+		attr.Enabled: types.BoolType,
+		attr.Gateway: types.ObjectType{AttrTypes: sshGatewayAttrTypes()},
+		attr.CA:      types.ObjectType{AttrTypes: sshCAAttrTypes()},
 	}
 }
 
@@ -470,13 +409,19 @@ func (r *gatewayConfig) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			attr.SSH: schema.SingleNestedAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "SSH configuration block containing gateway, CA, and resource settings.",
+				Description: "SSH configuration block containing gateway and CA settings.",
 				Default: objectdefault.StaticValue(types.ObjectValueMust(sshAttrTypes(), map[string]fwattr.Value{
-					attr.Gateway:   defaultGatewayObject(),
-					attr.CA:        defaultCAObject(),
-					attr.Resources: types.ListValueMust(sshResourceElemType(), []fwattr.Value{}),
+					attr.Enabled: types.BoolValue(false),
+					attr.Gateway: defaultGatewayObject(),
+					attr.CA:      defaultCAObject(),
 				})),
 				Attributes: map[string]schema.Attribute{
+					attr.Enabled: schema.BoolAttribute{
+						Optional:    true,
+						Computed:    true,
+						Description: "Whether the SSH protocol is enabled on the gateway. Default: false.",
+						Default:     booldefault.StaticBool(false),
+					},
 					attr.Gateway: schema.SingleNestedAttribute{
 						Optional:    true,
 						Computed:    true,
@@ -606,25 +551,21 @@ func (r *gatewayConfig) Schema(_ context.Context, _ resource.SchemaRequest, resp
 							},
 						},
 					},
-					attr.Resources: schema.ListAttribute{
-						Optional:    true,
-						Description: "List of SSH resources. Accepts full twingate_ssh_resource references.",
-						ElementType: sshResourceElemType(),
-					},
 				},
 			},
 			attr.Kubernetes: schema.SingleNestedAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Kubernetes configuration block containing resource settings.",
+				Description: "Kubernetes configuration block.",
 				Default: objectdefault.StaticValue(types.ObjectValueMust(kubernetesAttrTypes(), map[string]fwattr.Value{
-					attr.Resources: types.ListValueMust(kubernetesResourceElemType(), []fwattr.Value{}),
+					attr.Enabled: types.BoolValue(false),
 				})),
 				Attributes: map[string]schema.Attribute{
-					attr.Resources: schema.ListAttribute{
+					attr.Enabled: schema.BoolAttribute{
 						Optional:    true,
-						Description: "List of Kubernetes resources. Accepts full twingate_kubernetes_resource references.",
-						ElementType: kubernetesResourceElemType(),
+						Computed:    true,
+						Description: "Whether Kubernetes is enabled on the gateway. Default: false.",
+						Default:     booldefault.StaticBool(false),
 					},
 				},
 			},
@@ -647,37 +588,9 @@ func (gateway *gatewayConfigModel) generateContent(ctx context.Context, config p
 		return "", ErrExtractSSH
 	}
 
-	var sshRefs []sshResourceRef
-	if diags := sshConf.Resources.ElementsAs(ctx, &sshRefs, false); diags.HasError() {
-		return "", ErrExtractSSHResources
-	}
-
 	var k8sConf kubernetesModel
 	if diags := gateway.Kubernetes.As(ctx, &k8sConf, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return "", ErrExtractKubernetes
-	}
-
-	var k8sRefs []kubernetesResourceRef
-	if diags := k8sConf.Resources.ElementsAs(ctx, &k8sRefs, false); diags.HasError() {
-		return "", ErrExtractKubernetesResources
-	}
-
-	sshItems := make([]sshResourceData, 0, len(sshRefs))
-	for _, s := range sshRefs {
-		sshItems = append(sshItems, sshResourceData{
-			Name:     s.Name.ValueString(),
-			Address:  s.Address.ValueString(),
-			Username: s.Username.ValueString(),
-		})
-	}
-
-	k8sItems := make([]kubernetesResourceData, 0, len(k8sRefs))
-	for _, k := range k8sRefs {
-		k8sItems = append(k8sItems, kubernetesResourceData{
-			Name:      k.Name.ValueString(),
-			Address:   k.Address.ValueString(),
-			InCluster: k.InCluster.ValueBool(),
-		})
 	}
 
 	var tlsGW tlsModel
@@ -720,6 +633,7 @@ func (gateway *gatewayConfigModel) generateContent(ctx context.Context, config p
 			PrivateKeyFile:  tlsGW.PrivateKeyFile.ValueString(),
 		},
 		SSH: sshData{
+			Enabled: sshConf.Enabled.ValueBool(),
 			Gateway: sshGatewayData{
 				Username:    sshGW.Username.ValueString(),
 				KeyType:     sshGW.KeyType.ValueString(),
@@ -744,10 +658,9 @@ func (gateway *gatewayConfigModel) generateContent(ctx context.Context, config p
 					},
 				},
 			},
-			Resources: sshItems,
 		},
 		Kubernetes: kubernetesData{
-			Resources: k8sItems,
+			Enabled: k8sConf.Enabled.ValueBool(),
 		},
 	}
 
@@ -831,10 +744,10 @@ func (r *gatewayConfig) ValidateConfig(ctx context.Context, req resource.Validat
 		}
 	}
 
-	if sshConf.IsEmptyResources() && k8sConf.IsEmptyResources() {
+	if !sshConf.Enabled.ValueBool() && !k8sConf.Enabled.ValueBool() {
 		resp.Diagnostics.AddError(
 			"Invalid configuration",
-			`At least one of "ssh.resources" or "kubernetes.resources" must contain one or more items.`,
+			`At least one of "ssh.enabled" or "kubernetes.enabled" must be true.`,
 		)
 	}
 

--- a/twingate/internal/provider/resource/gateway-config.tmpl.yaml
+++ b/twingate/internal/provider/resource/gateway-config.tmpl.yaml
@@ -9,18 +9,12 @@ tls:
   certificateFile: {{ .TLS.CertificateFile }}
   privateKeyFile: {{ .TLS.PrivateKeyFile }}
 
-{{- if .Kubernetes.Resources }}
+{{- if .Kubernetes.Enabled }}
 
-kubernetes:
-  upstreams:
-  {{- range .Kubernetes.Resources }}
-  - name: {{ .Name }}
-    address: {{ .Address }}
-    inCluster: {{ .InCluster }}
-  {{- end }}
+kubernetes: {}
 {{- end }}
 
-{{- if .SSH.Resources }}
+{{- if .SSH.Enabled }}
 
 ssh:
   gateway:
@@ -57,13 +51,4 @@ ssh:
       privateKeyFile: {{ .SSH.CA.PrivateKeyFile }}
     {{- else }} null
     {{- end }}
-
-  upstreams:
-  {{- range .SSH.Resources }}
-  - name: {{ .Name }}
-    address: {{ .Address }}:22
-    {{- if .Username }}
-    user: {{ .Username }}
-    {{- end }}
-  {{- end }}
 {{- end }}

--- a/twingate/internal/provider/resource/gateway-config_test.go
+++ b/twingate/internal/provider/resource/gateway-config_test.go
@@ -206,96 +206,41 @@ func sshCAWithPrivateKey(keyFile string) types.Object {
 }
 
 var (
-	sshElemType = types.ObjectType{
-		AttrTypes: map[string]fwattr.Type{
-			"name":     types.StringType,
-			"address":  types.StringType,
-			"username": types.StringType,
-		},
-	}
-
-	k8sElemType = types.ObjectType{
-		AttrTypes: map[string]fwattr.Type{
-			"name":       types.StringType,
-			"address":    types.StringType,
-			"in_cluster": types.BoolType,
-		},
-	}
-
 	sshObjType = types.ObjectType{
 		AttrTypes: map[string]fwattr.Type{
-			"gateway":   sshGatewayObjType,
-			"ca":        sshCAObjType,
-			"resources": types.ListType{ElemType: sshElemType},
+			"enabled": types.BoolType,
+			"gateway": sshGatewayObjType,
+			"ca":      sshCAObjType,
 		},
 	}
 
 	k8sObjType = types.ObjectType{
 		AttrTypes: map[string]fwattr.Type{
-			"resources": types.ListType{ElemType: k8sElemType},
+			"enabled": types.BoolType,
 		},
 	}
 )
 
-func makeSshList(items ...map[string]fwattr.Value) types.List {
-	elems := make([]fwattr.Value, 0, len(items))
-	for _, item := range items {
-		elems = append(elems, types.ObjectValueMust(sshElemType.AttrTypes, item))
-	}
-	return types.ListValueMust(sshElemType, elems)
-}
-
-func makeK8sList(items ...map[string]fwattr.Value) types.List {
-	elems := make([]fwattr.Value, 0, len(items))
-	for _, item := range items {
-		elems = append(elems, types.ObjectValueMust(k8sElemType.AttrTypes, item))
-	}
-	return types.ListValueMust(k8sElemType, elems)
-}
-
-func makeSshObj(gateway, ca types.Object, resources types.List) types.Object {
+func makeSshObj(gateway, ca types.Object, enabled bool) types.Object {
 	return types.ObjectValueMust(sshObjType.AttrTypes, map[string]fwattr.Value{
-		"gateway":   gateway,
-		"ca":        ca,
-		"resources": resources,
+		"enabled": types.BoolValue(enabled),
+		"gateway": gateway,
+		"ca":      ca,
 	})
 }
 
-func defaultSshObj(resources types.List) types.Object {
-	return makeSshObj(defaultSshGateway(), defaultSshCA(), resources)
+func defaultSshObj(enabled bool) types.Object {
+	return makeSshObj(defaultSshGateway(), defaultSshCA(), enabled)
 }
 
-func makeK8sObj(resources types.List) types.Object {
+func makeK8sObj(enabled bool) types.Object {
 	return types.ObjectValueMust(k8sObjType.AttrTypes, map[string]fwattr.Value{
-		"resources": resources,
+		"enabled": types.BoolValue(enabled),
 	})
-}
-
-func defaultK8sObj() types.Object {
-	return makeK8sObj(makeK8sList())
-}
-
-func sshItem(name, address, username string) map[string]fwattr.Value {
-	return map[string]fwattr.Value{
-		"name":     types.StringValue(name),
-		"address":  types.StringValue(address),
-		"username": types.StringValue(username),
-	}
-}
-
-func k8sItem(name, address string, inCluster bool) map[string]fwattr.Value {
-	return map[string]fwattr.Value{
-		"name":       types.StringValue(name),
-		"address":    types.StringValue(address),
-		"in_cluster": types.BoolValue(inCluster),
-	}
 }
 
 func TestGatewayConfigGenerateContent(t *testing.T) {
 	ctx := context.Background()
-
-	baseSsh := makeSshList(sshItem("ssh-1", "10.0.0.1", "admin"))
-	baseK8s := makeK8sList(k8sItem("k8s-1", "10.0.0.2:6443", true))
 
 	cases := []struct {
 		name      string
@@ -308,8 +253,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVault("https://vault.example.com"), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVault("https://vault.example.com"), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -329,8 +274,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndToken("https://vault.example.com", "s.mytoken"), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndToken("https://vault.example.com", "s.mytoken"), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -346,8 +291,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndGCP("https://vault.example.com", "vm-role", "gce"), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndGCP("https://vault.example.com", "vm-role", "gce"), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -365,8 +310,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndGCPFull("https://vault.example.com", "vm-role", "gce", "custom-gcp", ""), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndGCPFull("https://vault.example.com", "vm-role", "gce", "custom-gcp", ""), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -380,8 +325,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndGCPFull("https://vault.example.com", "vm-role", "iam", defaultGCPMount, "sa@project.iam.gserviceaccount.com"), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVaultAndGCPFull("https://vault.example.com", "vm-role", "iam", defaultGCPMount, "sa@project.iam.gserviceaccount.com"), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -395,8 +340,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVault("https://vault.example.com"), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithVault("https://vault.example.com"), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -411,8 +356,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(defaultSshGateway(), sshCAWithPrivateKey("/etc/ssh/id_ed25519"), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(defaultSshGateway(), sshCAWithPrivateKey("/etc/ssh/id_ed25519"), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -429,8 +374,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -448,8 +393,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -458,53 +403,32 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			},
 		},
 		{
-			name: "ssh upstreams rendered correctly",
+			name: "ssh block has no upstreams",
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH: defaultSshObj(makeSshList(
-					sshItem("web", "192.168.1.10", "root"),
-					sshItem("db", "192.168.1.11", "postgres"),
-				)),
-				Kubernetes: makeK8sObj(baseK8s),
-				TLS:        defaultTLS(),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
+				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
 				ssh := doc["ssh"].(map[string]any)
-				upstreams := ssh["upstreams"].([]any)
-				assert.Len(t, upstreams, 2)
-				u0 := upstreams[0].(map[string]any)
-				assert.Equal(t, "web", u0["name"])
-				assert.Equal(t, "192.168.1.10:22", u0["address"])
-				assert.Equal(t, "root", u0["user"])
-				u1 := upstreams[1].(map[string]any)
-				assert.Equal(t, "db", u1["name"])
-				assert.Equal(t, "postgres", u1["user"])
+				assert.Contains(t, ssh, "gateway", "expected gateway block inside ssh")
+				assert.NotContains(t, ssh, "upstreams", "expected no upstreams key inside ssh")
 			},
 		},
 		{
-			name: "kubernetes upstreams rendered correctly",
+			name: "kubernetes block renders as empty map",
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes: makeK8sObj(makeK8sList(
-					k8sItem("prod-cluster", "10.1.0.1:6443", true),
-					k8sItem("dev-cluster", "10.2.0.1:6443", false),
-				)),
-				TLS: defaultTLS(),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
+				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
 				k8s := doc["kubernetes"].(map[string]any)
-				upstreams := k8s["upstreams"].([]any)
-				assert.Len(t, upstreams, 2)
-				u0 := upstreams[0].(map[string]any)
-				assert.Equal(t, "prod-cluster", u0["name"])
-				assert.Equal(t, "10.1.0.1:6443", u0["address"])
-				assert.Equal(t, true, u0["inCluster"])
-				u1 := upstreams[1].(map[string]any)
-				assert.Equal(t, "dev-cluster", u1["name"])
-				assert.Equal(t, false, u1["inCluster"])
+				assert.Empty(t, k8s, "expected kubernetes to render as an empty map")
 			},
 		},
 		{
@@ -512,8 +436,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         makeSshObj(customSshGateway("ops", "rsa", "12h", "30m"), defaultSshCA(), baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         makeSshObj(customSshGateway("ops", "rsa", "12h", "30m"), defaultSshCA(), true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -530,8 +454,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -548,8 +472,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(9443),
 				MetricsPort: types.Int64Value(9091),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -562,9 +486,9 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
+				SSH:         defaultSshObj(true),
 				TLS:         customTLS("/custom/tls.crt", "/custom/tls.key"),
-				Kubernetes:  makeK8sObj(baseK8s),
+				Kubernetes:  makeK8sObj(true),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
 				tls := doc["tls"].(map[string]any)
@@ -573,12 +497,12 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			},
 		},
 		{
-			name: "only ssh resources — kubernetes block absent",
+			name: "only ssh enabled — kubernetes block absent",
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes:  makeK8sObj(makeK8sList()),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(false),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -587,12 +511,12 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			},
 		},
 		{
-			name: "only kubernetes resources — ssh block absent",
+			name: "only kubernetes enabled — ssh block absent",
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(makeSshList()),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         defaultSshObj(false),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {
@@ -605,8 +529,8 @@ func TestGatewayConfigGenerateContent(t *testing.T) {
 			model: gatewayConfigModel{
 				Port:        types.Int64Value(defaultPort),
 				MetricsPort: types.Int64Value(defaultMetricsPort),
-				SSH:         defaultSshObj(baseSsh),
-				Kubernetes:  makeK8sObj(baseK8s),
+				SSH:         defaultSshObj(true),
+				Kubernetes:  makeK8sObj(true),
 				TLS:         defaultTLS(),
 			},
 			checkYAML: func(t *testing.T, doc map[string]any) {


### PR DESCRIPTION
Resolves https://github.com/Twingate/terraform-provider-twingate/issues/894

## Changes

The Gateway removed `upstreams` from its config: SSH upstream address/user now come from the runtime connection and in-cluster Kubernetes is implicit, so the resource lists no longer feed any output.

- Replace `ssh.resources` / `kubernetes.resources` with an `enabled` flag; SSH and Kubernetes are now enabled explicitly instead of inferred from resource lists
- Generated config no longer emits `ssh.upstreams`; `kubernetes` renders as `{}` when enabled
- Update docs and examples accordingly