### PR TITLE
Add tools/upgrader Go module to dependabot gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
+  allow:
+    - dependency-type: all
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directories:
+    - "/"
+    - "/tools/upgrader"
   schedule:
     interval: daily
     time: "13:00"


### PR DESCRIPTION
## Changes

`tools/upgrader` has its own `go.mod`, separate from the root module, but it wasn't covered by Dependabot's `gomod` config, so its dependencies never received automated update PRs.

This adds it to the existing `gomod` entry using the `directories` (plural) field, which accepts a list of paths.