### PR TITLE
[Docs] Regenerate docs after the terraform-plugin-docs bump

### DIFF
--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -53,6 +53,8 @@ resource "twingate_connector" "aws_connector" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import twingate_connector.aws_connector Q29ubmVjdG9yOjI2NzM=
 ```

--- a/docs/resources/dns_filtering_profile.md
+++ b/docs/resources/dns_filtering_profile.md
@@ -154,6 +154,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import twingate_dns_filtering_profile.example RG5zRmlsdGVyaW5nUHJvZmlsZToxY2I4YzM0YTc0
 ```

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -43,6 +43,8 @@ resource "twingate_group" "aws" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import twingate_group.aws R3JvdXA6MzQ4OTE=
 ```

--- a/docs/resources/remote_network.md
+++ b/docs/resources/remote_network.md
@@ -43,6 +43,8 @@ resource "twingate_remote_network" "aws_network" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import twingate_remote_network.network UmVtb3RlTmV0d29zaipgMKIkNg==
 ```

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -249,6 +249,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import twingate_resource.resource UmVzb3VyY2U6MzQwNDQ3
 ```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -50,6 +50,8 @@ resource "twingate_user" "user" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import twingate_user.user VXNlcjo1ODk3MTM=
 ```


### PR DESCRIPTION
## Summary

`Test docs up-to-date` currently fails on every open PR, including on a branch with no changes of its own. The bump to terraform-plugin-docs 0.25.0 in #951 changed the import-section template, but the generated docs were not regenerated in that PR.

This is the output of `make docs` on an otherwise-clean `main` — one added line per resource that documents an import:

```
The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
```

No provider or schema changes; only generated files.

## Verification

Generated with terraform 1.14.9 (per `.tool-versions`) — an older terraform produces extra spurious changes, notably deleting `docs/ephemeral-resources/connector_tokens.md` and dropping the write-only note from `docs/resources/x509_certificate_authority.md`, so those are not in this diff. After this lands, `make docs` on main is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)