### PR TITLE
chore: Switch coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
         files: ./test_results/final_coverage.out
         flags: unit
         disable_search: true
-        fail_ci_if_error: true
+        # Fork PRs get no OIDC token, so the action falls back to a tokenless
+        # upload — which can hit GitHub's shared rate limit. Don't fail a
+        # contributor's CI over that; stay strict everywhere else.
+        fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
 
   cleanup-before-acctests:
     name: Cleanup before acceptance tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         make test
 
     - name: Send coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         use_oidc: true
         files: ./test_results/final_coverage.out
@@ -212,7 +212,7 @@ jobs:
         make testacc
 
     - name: Send coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         use_oidc: true
         files: ./test_results/final_coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
     name: Unit Tests
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
 
     - name: Check out code into the Go module directory
@@ -113,11 +116,13 @@ jobs:
         make test
 
     - name: Send coverage
-      uses: shogo82148/actions-goveralls@v1
+      uses: codecov/codecov-action@v5
       with:
-        path-to-profile: "./test_results/final_coverage.out"
-        flag-name: tests
-        parallel: true
+        use_oidc: true
+        files: ./test_results/final_coverage.out
+        flags: unit
+        disable_search: true
+        fail_ci_if_error: true
 
   cleanup-before-acctests:
     name: Cleanup before acceptance tests
@@ -156,13 +161,18 @@ jobs:
     needs: [build, cleanup-before-acctests]
     runs-on: ubuntu-latest
     if: "!github.event.pull_request.head.repo.fork"
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       max-parallel: 3
       fail-fast: false
       matrix:
-        terraform:
-          - '1.15.*'
-          - 'latest'
+        include:
+          - terraform: '1.15.*'
+            flag: acc-tf-1.15
+          - terraform: 'latest'
+            flag: acc-tf-latest
     steps:
 
     - name: Check out code into the Go module directory
@@ -199,11 +209,13 @@ jobs:
         make testacc
 
     - name: Send coverage
-      uses: shogo82148/actions-goveralls@v1
+      uses: codecov/codecov-action@v5
       with:
-        path-to-profile: "./test_results/final_coverage.out"
-        flag-name: tests-acc-${{ matrix.terraform }}
-        parallel: true
+        use_oidc: true
+        files: ./test_results/final_coverage.out
+        flags: ${{ matrix.flag }}
+        disable_search: true
+        fail_ci_if_error: true
 
   tests-acceptance-opentofu:
     name: OpenTofu Matrix Acceptance Tests
@@ -298,6 +310,4 @@ jobs:
     needs: [tests-unit, tests-acceptance, tests-acceptance-opentofu, cleanup]
     runs-on: ubuntu-latest
     steps:
-      - uses: shogo82148/actions-goveralls@v1
-        with:
-          parallel-finished: true
+      - run: echo "All CI jobs finished."

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Twingate Terraform Provider
 
-[![Coverage Status](https://coveralls.io/repos/github/Twingate/terraform-provider-twingate/badge.svg?branch=main&t=rqgifB)](https://coveralls.io/github/Twingate/terraform-provider-twingate?branch=main)
+[![codecov](https://codecov.io/gh/Twingate/terraform-provider-twingate/branch/main/graph/badge.svg)](https://codecov.io/gh/Twingate/terraform-provider-twingate)
 
 ## Requirements
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Acceptance tests don't run on fork PRs, so their flags would otherwise
+# report as a coverage drop instead of "unchanged".
+flag_management:
+  default_rules:
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "twingate/internal/test/**"
+  - "tools/**"
+  - "examples/**"


### PR DESCRIPTION
## Changes

Swaps `shogo82148/actions-goveralls` for `codecov/codecov-action@v7` in CI.

**`.github/workflows/ci.yml`**
- Both `Send coverage` steps now upload the existing `./test_results/final_coverage.out` profile to Codecov. Coverage generation in `scripts/test.sh` is untouched.
- Uploads authenticate with **GitHub OIDC** (`use_oidc: true`), so there's no `CODECOV_TOKEN` secret to manage. This needs `id-token: write` on the uploading jobs. A job-level `permissions:` block overrides the workflow default rather than adding to it, so those two jobs restate `contents: read` next to it; the workflow-level `permissions: read-all` stays as the default for every other job.
- Fork PRs: GitHub never grants `id-token: write` to a `pull_request` run from a fork, and the action detects that and falls back to a tokenless upload on its own. Tokenless is subject to a shared GitHub rate limit, so `fail_ci_if_error` on the unit-test upload is conditional on the PR not being a fork — a Codecov-side hiccup shouldn't fail an external contributor's `Unit Tests` job. Uploads on `main` and on branch PRs stay strict. (The acceptance jobs already skip fork PRs entirely.)
- Codecov merges a commit's uploads on its own, so the goveralls `parallel` / `parallel-finished` handshake is gone. The `CI Finished` job keeps its name and `needs:` list (it's a required check) and becomes a plain gate.
- Codecov flags can't contain `*`, so the acceptance matrix moves to `include` entries pairing each Terraform version with a clean flag (`acc-tf-1.15`, `acc-tf-latest`). Job display names and `TEST_UNIQUE_VALUE` are unaffected.
- The OpenTofu acceptance matrix is unchanged — it uploads no coverage today, same as before.

**`codecov.yml`** (new)
- `project` and `patch` statuses are blocking at `target: auto, threshold: 1%`.
- `carryforward: true` — acceptance jobs are skipped on fork PRs, which would otherwise read as a large coverage drop and fail the blocking status.
- `ignore` drops `twingate/internal/test/**` from the denominator. Today that's 3 non-`_test.go` helpers that are currently counted (tests run with `-coverpkg=./twingate/...`); the glob covers the whole tree because everything under it is test scaffolding by construction. Since both statuses use `target: auto`, this is a one-time baseline shift rather than an ongoing discrepancy — happy to drop the block if you'd rather keep the number comparable to the Coveralls history.

**`README.md`** — Codecov badge replaces the Coveralls one.

## Verification

- No `coveralls`/`goveralls` references remain in the repo.
- Both YAML files parse; `actionlint` reports nothing on the changed lines (its findings are pre-existing shellcheck notes on untouched `go env` lines).
- `make test` passes locally (1828 tests) and still writes a valid `mode: set` profile at the expected path.

## Needs a repo admin — one step BEFORE merge

`main`'s branch protection still lists **`coverage/coveralls`** as a required status check. This PR removes the Coveralls upload, so that check will never report again and the PR stays `BLOCKED` even with an approval and every other check green. An admin has to drop `coverage/coveralls` from the required list before this can merge.

While in there: add `codecov/project` and `codecov/patch` as required checks (both already report on this PR), and deactivate the Coveralls app once the first report lands on `main`.

Nothing has to be switched on for OIDC on the Codecov side: there's no per-repo OIDC toggle, it's entirely `use_oidc: true` + `id-token: write` in the workflow. The only prerequisite is the repo being active in the Codecov org, which the Codecov comment on this PR confirms it is. If an upload does fail auth, the fallback is swapping `use_oidc: true` for `token: ${{ secrets.CODECOV_TOKEN }}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
