### PR TITLE
fix: Stop sending an all-inclusive type filter in the groups query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .*.swp
 *.iml
 *.test
+*.tmp
 
 # terraform files
 terraform.tfvars

--- a/twingate/internal/client/query/groups-read.go
+++ b/twingate/internal/client/query/groups-read.go
@@ -31,9 +31,9 @@ func (u Groups) ToModel() []*model.Group {
 }
 
 type GroupFilterInput struct {
-	Name     *StringFilterOperationInput  `json:"name"`
-	Type     GroupTypeFilterOperatorInput `json:"type"`
-	IsActive BooleanFilterOperatorInput   `json:"isActive"`
+	Name     *StringFilterOperationInput   `json:"name"`
+	Type     *GroupTypeFilterOperatorInput `json:"type,omitempty"`
+	IsActive BooleanFilterOperatorInput    `json:"isActive"`
 }
 
 type StringFilterOperationInput struct {
@@ -92,15 +92,8 @@ func NewGroupFilterInput(input *model.GroupsFilter) *GroupFilterInput {
 		return nil
 	}
 
-	// default filter settings
+	// groups are filtered by active state unless the caller asks otherwise
 	filter := &GroupFilterInput{
-		Type: GroupTypeFilterOperatorInput{
-			In: []string{
-				model.GroupTypeManual,
-				model.GroupTypeSynced,
-				model.GroupTypeSystem,
-			},
-		},
 		IsActive: BooleanFilterOperatorInput{Eq: true},
 	}
 
@@ -113,7 +106,7 @@ func NewGroupFilterInput(input *model.GroupsFilter) *GroupFilterInput {
 	}
 
 	if len(input.Types) > 0 {
-		filter.Type.In = input.Types
+		filter.Type = &GroupTypeFilterOperatorInput{In: input.Types}
 	}
 
 	if input.IsActive != nil {

--- a/twingate/internal/client/query/query_test.go
+++ b/twingate/internal/client/query/query_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -1041,11 +1042,6 @@ func optionalBool(val bool) *bool {
 
 func TestBuildGroupsFilter(t *testing.T) {
 	defaultActive := BooleanFilterOperatorInput{Eq: true}
-	defaultType := GroupTypeFilterOperatorInput{
-		In: []string{model.GroupTypeManual,
-			model.GroupTypeSynced,
-			model.GroupTypeSystem},
-	}
 
 	testCases := []struct {
 		filter   *model.GroupsFilter
@@ -1061,14 +1057,13 @@ func TestBuildGroupsFilter(t *testing.T) {
 				Name: &StringFilterOperationInput{
 					Eq: optionalString("Group"),
 				},
-				Type:     defaultType,
 				IsActive: defaultActive,
 			},
 		},
 		{
 			filter: &model.GroupsFilter{Types: []string{"MANUAL"}},
 			expected: &GroupFilterInput{
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeManual},
 				},
 				IsActive: defaultActive,
@@ -1077,7 +1072,7 @@ func TestBuildGroupsFilter(t *testing.T) {
 		{
 			filter: &model.GroupsFilter{Types: []string{"SYSTEM"}},
 			expected: &GroupFilterInput{
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeSystem},
 				},
 				IsActive: defaultActive,
@@ -1086,7 +1081,7 @@ func TestBuildGroupsFilter(t *testing.T) {
 		{
 			filter: &model.GroupsFilter{Types: []string{"SYNCED"}},
 			expected: &GroupFilterInput{
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeSynced},
 				},
 				IsActive: defaultActive,
@@ -1095,14 +1090,12 @@ func TestBuildGroupsFilter(t *testing.T) {
 		{
 			filter: &model.GroupsFilter{IsActive: optionalBool(true)},
 			expected: &GroupFilterInput{
-				Type:     defaultType,
 				IsActive: BooleanFilterOperatorInput{Eq: true},
 			},
 		},
 		{
 			filter: &model.GroupsFilter{IsActive: optionalBool(false)},
 			expected: &GroupFilterInput{
-				Type:     defaultType,
 				IsActive: BooleanFilterOperatorInput{Eq: false},
 			},
 		},
@@ -1112,7 +1105,7 @@ func TestBuildGroupsFilter(t *testing.T) {
 				IsActive: optionalBool(false),
 			},
 			expected: &GroupFilterInput{
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeSystem},
 				},
 				IsActive: BooleanFilterOperatorInput{Eq: false},
@@ -1124,7 +1117,7 @@ func TestBuildGroupsFilter(t *testing.T) {
 				IsActive: optionalBool(true),
 			},
 			expected: &GroupFilterInput{
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeManual},
 				},
 				IsActive: BooleanFilterOperatorInput{Eq: true},
@@ -1136,7 +1129,7 @@ func TestBuildGroupsFilter(t *testing.T) {
 				IsActive: optionalBool(false),
 			},
 			expected: &GroupFilterInput{
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeManual},
 				},
 				IsActive: BooleanFilterOperatorInput{Eq: false},
@@ -1151,7 +1144,6 @@ func TestBuildGroupsFilter(t *testing.T) {
 				Name: &StringFilterOperationInput{
 					In: []string{"Group A", "Group B"},
 				},
-				Type:     defaultType,
 				IsActive: defaultActive,
 			},
 		},
@@ -1166,7 +1158,7 @@ func TestBuildGroupsFilter(t *testing.T) {
 				Name: &StringFilterOperationInput{
 					In: []string{"Group A"},
 				},
-				Type: GroupTypeFilterOperatorInput{
+				Type: &GroupTypeFilterOperatorInput{
 					In: []string{model.GroupTypeManual},
 				},
 				IsActive: BooleanFilterOperatorInput{Eq: false},
@@ -1178,6 +1170,56 @@ func TestBuildGroupsFilter(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", n), func(t *testing.T) {
 
 			assert.Equal(t, td.expected, NewGroupFilterInput(td.filter))
+		})
+	}
+}
+
+func TestBuildGroupsFilterSerialization(t *testing.T) {
+	// GraphQL input-object keys, deliberately spelled out here rather than reused
+	// from the attr package, which holds terraform schema names (`is_active`).
+	const (
+		typeKey     = "type"
+		isActiveKey = "isActive"
+	)
+
+	testCases := []struct {
+		name         string
+		filter       *model.GroupsFilter
+		expectedType map[string]any
+	}{
+		{
+			name:   "types not set: the type filter is not sent",
+			filter: &model.GroupsFilter{Name: optionalString("foo"), NameFilter: attr.FilterByContains},
+		},
+		{
+			name:   "only is_active set: the type filter is not sent",
+			filter: &model.GroupsFilter{IsActive: optionalBool(true)},
+		},
+		{
+			name:         "types set: the type filter carries exactly those values",
+			filter:       &model.GroupsFilter{Types: []string{model.GroupTypeManual}},
+			expectedType: map[string]any{"in": []any{model.GroupTypeManual}},
+		},
+	}
+
+	for _, td := range testCases {
+		t.Run(td.name, func(t *testing.T) {
+			payload, err := json.Marshal(NewGroupFilterInput(td.filter))
+			assert.NoError(t, err)
+
+			var actual map[string]any
+
+			assert.NoError(t, json.Unmarshal(payload, &actual))
+
+			typeFilter, ok := actual[typeKey]
+			assert.Equal(t, td.expectedType != nil, ok, "unexpected `type` filter in payload %s", payload)
+
+			if td.expectedType != nil {
+				assert.Equal(t, td.expectedType, typeFilter)
+			}
+
+			// the isActive filter is deliberately sent on every request
+			assert.Contains(t, actual, isActiveKey)
 		})
 	}
 }


### PR DESCRIPTION
## What

`NewGroupFilterInput` seeded **every** `twingate_groups` query with

```json
"type": {"in": ["MANUAL", "SYNCED", "SYSTEM"]}
```

even when the config never mentioned `types`. So this:

```hcl
data "twingate_groups" "foo" {
  name_contains = "foo"
}
```

sent a type filter the user never asked for.

## Why it matters

`MANUAL`/`SYNCED`/`SYSTEM` is the complete set of group types the provider knows (`model/group.go:11-15` — the same three are the only values accepted by the `types` validator and by the provider-level cache filter). So the filter selects everything and is a no-op **today**.

The problem is that it's a hardcoded allow-list. The day the Twingate API grows a fourth group type, this silently turns into an *exclusion* filter and the provider stops returning groups it should — with no error and nothing in the schema hinting at why.

These defaults were not a deliberate product decision. They arrived in b1cb43a "Fix group filtering using API (#271)", which moved filtering from a client-side `GroupsFilter.Match` helper into the GraphQL `filter:` argument. The helper it replaced applied `Type`/`IsActive` **only when non-nil** — no defaults. No rationale in the commit message, no accompanying doc change.

## The change

`GroupFilterInput.Type` becomes an optional pointer with `omitempty`, allocated only when the caller sets `types`:

```go
Type *GroupTypeFilterOperatorInput `json:"type,omitempty"`
```

Payload before / after, for `name_contains = "foo"`:

```diff
-{"name":{...,"contains":"foo",...},"type":{"in":["MANUAL","SYNCED","SYSTEM"]},"isActive":{"eq":true}}
+{"name":{...,"contains":"foo",...},"isActive":{"eq":true}}
```

When `types` **is** set, nothing changes: `{"type":{"in":["MANUAL"]},...}`.

Note this is the first use of `omitempty` in the repo — the prevailing convention is pointer + nil → explicit `null`, as `name` still does. `omitempty` is deliberate here because the goal is the key's *absence*, not a `null`.

## Not in scope

The sibling `isActive: {eq: true}` default is **left exactly as it is**. Removing it would be user-visible — `data "twingate_groups" { name = "x" }` would start returning inactive groups — so it belongs in its own appropriately-flagged change.

Two related inconsistencies turned up while investigating, both untouched here and worth a follow-up:

- `buildFilter` returns `nil` when no filter attribute is set, so `data "twingate_groups" "all" {}` sends no filter and *does* return inactive groups — while `{ name = "x" }` silently restricts to active. Same datasource, opposite semantics.
- The cache path (`model.Group.Match`) applies `isActive` only when explicitly set, so it already disagrees with the API path's default.

## Behavior change

None for the three known group types. A future server-side group type will no longer be silently excluded.

## Tests

- `TestBuildGroupsFilter` — updated; it asserts whole-struct equality, so every non-nil case needed its `Type` expectation adjusted.
- `TestBuildGroupsFilterSerialization` — **new**. Asserts on the marshaled JSON payload, which nothing previously covered (the client tests use `httpmock` responders and never read the request body). Checks that `type` is absent when unset, present with exactly the given values when set, and that `isActive` is still sent in both cases — that last one locks in the deliberate decision above, so a future change to it has to be conscious.

Verified locally: `go build ./...`, full `go test ./twingate/internal/...`, `gofmt` clean, and `tfplugindocs generate` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)