### PR TITLE
Fix: sweep x509 certs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     name: Matrix Acceptance Tests
     needs: [build]
     runs-on: ubuntu-latest
-#    if: "!github.event.pull_request.head.repo.fork"
+    if: "!github.event.pull_request.head.repo.fork"
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - 'README.md'
     branches:
       - main
+      - fix/sweep-x509-certs
 
 # Dependabot PRs all sweep the same shared Twingate tenant, so they share one
 # concurrency group and queue rather than run in parallel. Every other run keeps
@@ -129,41 +130,9 @@ jobs:
         # contributor's CI over that; stay strict everywhere else.
         fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
 
-  cleanup-before-acctests:
-    name: Cleanup before acceptance tests
-    runs-on: ubuntu-latest
-    if: "!github.event.pull_request.head.repo.fork"
-    timeout-minutes: 10
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: go env
-        run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Run x509 certificate authority sweepers
-        timeout-minutes: 10
-        env:
-          TWINGATE_URL: ${{ secrets.TWINGATE_URL }}
-          TWINGATE_NETWORK: ${{ secrets.TWINGATE_NETWORK }}
-          TWINGATE_API_TOKEN: ${{ secrets.TWINGATE_API_TOKEN }}
-        run: |
-          make sweep-all-twingate_x509_certificate_authority
-
   tests-acceptance:
     name: Matrix Acceptance Tests
-    needs: [build, cleanup-before-acctests]
+    needs: [build]
     runs-on: ubuntu-latest
     if: "!github.event.pull_request.head.repo.fork"
     permissions:
@@ -224,7 +193,7 @@ jobs:
 
   tests-acceptance-opentofu:
     name: OpenTofu Matrix Acceptance Tests
-    needs: [build, cleanup-before-acctests]
+    needs: [build]
     runs-on: ubuntu-latest
     if: "!github.event.pull_request.head.repo.fork"
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     name: Matrix Acceptance Tests
     needs: [build]
     runs-on: ubuntu-latest
-    if: "!github.event.pull_request.head.repo.fork"
+#    if: "!github.event.pull_request.head.repo.fork"
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
       - 'README.md'
     branches:
       - main
-      - fix/sweep-x509-certs
 
 # Dependabot PRs all sweep the same shared Twingate tenant, so they share one
 # concurrency group and queue rather than run in parallel. Every other run keeps

--- a/.github/workflows/cleanup-certificate-authorities.yml
+++ b/.github/workflows/cleanup-certificate-authorities.yml
@@ -1,0 +1,51 @@
+# Deletes all x509 certificate authorities (CAs) from the test Twingate tenant
+name: Cleanup Certificate Authorities
+permissions: read-all
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Cleanup
+    if: "!github.event.repository.fork"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check that no test runs are in progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for workflow in ci.yml smoketests.yml; do
+            active=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$workflow" --limit 100 \
+              --json status --jq '[.[] | select(.status != "completed")] | length')
+            if [ "$active" -gt 0 ]; then
+              echo "::error::$workflow has $active run(s) in progress. Wait for them to finish or cancel them, then run this workflow again."
+              exit 1
+            fi
+          done
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+        id: go
+
+      - name: go env
+        run: echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
+      - name: Get dependencies
+        run: |
+          go mod download
+
+      - name: Run sweepers
+        timeout-minutes: 10
+        env:
+          TWINGATE_URL: ${{ secrets.TWINGATE_URL }}
+          TWINGATE_NETWORK: ${{ secrets.TWINGATE_NETWORK }}
+          TWINGATE_API_TOKEN: ${{ secrets.TWINGATE_API_TOKEN }}
+        run: |
+          make sweep-all-twingate_x509_certificate_authority

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -37,15 +37,6 @@ jobs:
       run: |
         make build
 
-    - name: Run sweepers
-      timeout-minutes: 10
-      env:
-        TWINGATE_URL: ${{ secrets.TWINGATE_URL }}
-        TWINGATE_NETWORK: ${{ secrets.TWINGATE_NETWORK }}
-        TWINGATE_API_TOKEN: ${{ secrets.TWINGATE_API_TOKEN }}
-      run: |
-        make sweep-all-twingate_x509_certificate_authority
-
   tests-acceptance:
     name: Matrix Acceptance Tests
     needs: build


### PR DESCRIPTION
Tests passes: https://github.com/vmanilo/terraform-provider-twingate/actions/runs/34503635051

## Changes
- removed cleanup step before each CI run
- set on demand action to clean up certs
